### PR TITLE
fix: resolve "Can't set headers after they are sent" warning in preview API endpoint

### DIFF
--- a/package/src/redirectToPreviewURL.ts
+++ b/package/src/redirectToPreviewURL.ts
@@ -36,6 +36,8 @@ export async function redirectToPreviewURL({
 		});
 
 		res.redirect(previewUrl);
+
+		return;
 	}
 
 	res.redirect(defaultURL);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

redirectToPreviewUrl was throwing an error because it was trying to set headers multiple times. I added a return statement

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

![baby goat](https://user-images.githubusercontent.com/1852675/150809797-00ae9e8b-83f7-4aa2-aadc-40b1da6234cf.jpeg)



