### PR TITLE
fix: prevent CDN-level caching of exit preview route implemented with `exitPreview()`

### DIFF
--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -32,6 +32,7 @@ export type ExitPreviewConfig = {
 	 */
 	res: {
 		clearPreviewData: NextApiResponse["clearPreviewData"];
+		status: NextApiResponse["status"];
 		json: NextApiResponse["json"];
 	};
 
@@ -48,5 +49,7 @@ export function exitPreview(config: ExitPreviewConfig): void {
 	// Exit the current user from Preview Mode.
 	config.res.clearPreviewData();
 
-	config.res.json({ success: true });
+	// 205 status is used to prevent CDN-level caching. The default 200
+	// status code is typically treated as non-changing and cacheable.
+	config.res.status(205).json({ success: true });
 }

--- a/test/exitPreview.test.ts
+++ b/test/exitPreview.test.ts
@@ -7,6 +7,7 @@ test("clears preview data", () => {
 		res: {
 			clearPreviewData: vi.fn(),
 			json: vi.fn(),
+			status: vi.fn().mockImplementation(() => config.res),
 		},
 		req: {
 			headers: {},
@@ -18,11 +19,12 @@ test("clears preview data", () => {
 	expect(config.res.clearPreviewData).toHaveBeenCalled();
 });
 
-test("responds with JSON success message", () => {
+test("responds with 205 status code and JSON success message", () => {
 	const config: ExitPreviewConfig = {
 		res: {
 			clearPreviewData: vi.fn(),
 			json: vi.fn(),
+			status: vi.fn().mockImplementation(() => config.res),
 		},
 		req: {
 			headers: {},
@@ -31,5 +33,6 @@ test("responds with JSON success message", () => {
 
 	exitPreview(config);
 
+	expect(config.res.status).toHaveBeenCalledWith(205);
 	expect(config.res.json).toHaveBeenCalledWith({ success: true });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR prevents CDN-level caching of the exit preview route when implemented with `exitPreview()`. Vercel, for example, was caching the `/api/exit-preview` API endpoint after the first request.

Before this PR, `exitPreview()` returned a 200 status code along with a JSON success message (`{ success: true }`).

As of this PR, `exitPreview()` returns a [205 status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/205). The 205 code does not allow any content to be returned, thus the JSON success message has been removed. A `205` status code sufficiently signals success.

Fixes #31.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
