### PR TITLE
fix: support tree-shaking

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,0 +1,19 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+	hooks: {
+		"rollup:options": (_ctx, options) => {
+			const outputOptions = Array.isArray(options.output)
+				? options.output
+				: [options.output];
+
+			options.output = outputOptions.map((options) => {
+				return {
+					...options,
+					preserveModules: true,
+					preserveModulesRoot: "src",
+				};
+			});
+		},
+	},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
 				"@prismicio/react": "^2.5.0",
 				"@prismicio/types": "^0.2.3",
 				"eslint-plugin-react": "^7.30.1",
-				"eslint-plugin-react-hooks": "^4.6.0"
+				"eslint-plugin-react-hooks": "^4.6.0",
+				"imgix-url-builder": "^0.0.3"
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.1.1",
@@ -34,10 +35,10 @@
 				"prettier-plugin-jsdoc": "^0.3.38",
 				"react": "^18.1.0",
 				"react-test-renderer": "^18.2.0",
-				"siroc": "^0.16.0",
 				"size-limit": "^8.0.1",
 				"standard-version": "^9.5.0",
 				"typescript": "^4.7.4",
+				"unbuild": "^0.8.9",
 				"vitest": "^0.22.1"
 			},
 			"engines": {
@@ -404,6 +405,15 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@babel/standalone": {
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.18.13.tgz",
+			"integrity": "sha512-5hjvvFkaXyfQri+s4CAZtx6FTKclfTNd2QN2RwgzCVJhnYYgKh4YFBCnNJSxurzvpSKD2NmpCkoWAkMc+j9y+g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/template": {
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
@@ -674,6 +684,34 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1066,44 +1104,6 @@
 				"rollup": "^1.20.0||^2.0.0"
 			}
 		},
-		"node_modules/@rollup/plugin-commonjs": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
-			"integrity": "sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==",
-			"dev": true,
-			"dependencies": {
-				"@rollup/pluginutils": "^3.1.0",
-				"commondir": "^1.0.1",
-				"estree-walker": "^2.0.1",
-				"glob": "^7.1.6",
-				"is-reference": "^1.2.1",
-				"magic-string": "^0.25.7",
-				"resolve": "^1.17.0"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^2.38.3"
-			}
-		},
-		"node_modules/@rollup/plugin-commonjs/node_modules/resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.9.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/@rollup/plugin-json": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -1151,19 +1151,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/@rollup/plugin-replace": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-3.1.0.tgz",
-			"integrity": "sha512-pA3XRUrSKybVYqmH5TqWNZpGxF+VV+1GrYchKgCNIj2vsSOX7CVm2RCtx8p2nrC7xvkziYyK+lSi74T93MU3YA==",
-			"dev": true,
-			"dependencies": {
-				"@rollup/pluginutils": "^3.1.0",
-				"magic-string": "^0.25.7"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0 || ^2.0.0"
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -1290,16 +1277,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-			"dev": true,
-			"dependencies": {
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -1320,12 +1297,6 @@
 			"dependencies": {
 				"@types/unist": "*"
 			}
-		},
-		"node_modules/@types/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
 		},
 		"node_modules/@types/minimist": {
 			"version": "1.2.2",
@@ -1912,15 +1883,6 @@
 				"node": ">=10.12.0"
 			}
 		},
-		"node_modules/cac": {
-			"version": "6.7.12",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.12.tgz",
-			"integrity": "sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/caching-transform": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -2189,6 +2151,14 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/comment-parser": {
 			"version": "1.3.1",
@@ -2684,12 +2654,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/defu": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
-			"integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
-			"dev": true
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2909,6 +2873,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"dev": true
 		},
 		"node_modules/es-shim-unscopables": {
 			"version": "1.0.0",
@@ -3616,29 +3586,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4014,18 +3961,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/get-symbol-description": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -4039,15 +3974,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/git-hooks-list": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
-			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/fisker/git-hooks-list?sponsor=1"
 			}
 		},
 		"node_modules/git-raw-commits": {
@@ -4342,6 +4268,12 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/hookable": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.2.2.tgz",
+			"integrity": "sha512-J+tYTxF7bOYEQX2MJ3jWWjAKhQLzRAf0efkxyNfuSnIFLl3AXOpkuOVpVhBx5zMSeGPzIUNN5FpYQaA1eYzfVQ==",
+			"dev": true
+		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -4428,15 +4360,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
 			"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
 			"dev": true
-		},
-		"node_modules/human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.17.0"
-			}
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
@@ -4697,15 +4620,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -5253,15 +5167,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dev": true,
-			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5532,12 +5437,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -6023,15 +5922,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6497,6 +6387,24 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/mlly": {
+			"version": "0.5.14",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-0.5.14.tgz",
+			"integrity": "sha512-DgRgNUSX9NIxxCxygX4Xeg9C7GX7OUx1wuQ8cXx9o9LE0e9wrH+OZ9fcnrlEedsC/rtqry3ZhUddC759XD/L0w==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"pathe": "^0.3.5",
+				"pkg-types": "^0.3.4",
+				"ufo": "^0.8.5"
+			}
+		},
+		"node_modules/mlly/node_modules/pathe": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.5.tgz",
+			"integrity": "sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==",
+			"dev": true
+		},
 		"node_modules/modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -6675,18 +6583,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/nyc": {
@@ -6961,21 +6857,6 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"dependencies": {
-				"mimic-fn": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/optionator": {
@@ -7260,6 +7141,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pkg-types": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-0.3.4.tgz",
+			"integrity": "sha512-s214f/xkRpwlwVBToWq9Mu0XlU3HhZMYCnr2var8+jjbavBHh/VCh4pBLsJW29rJ//B1jb4HlpMIaNIMH+W2/w==",
+			"dev": true,
+			"dependencies": {
+				"jsonc-parser": "^3.1.0",
+				"mlly": "^0.5.13",
+				"pathe": "^0.3.5"
+			}
+		},
+		"node_modules/pkg-types/node_modules/pathe": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.5.tgz",
+			"integrity": "sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==",
+			"dev": true
+		},
 		"node_modules/postcss": {
 			"version": "8.4.14",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -7334,6 +7232,18 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=2.1.2"
+			}
+		},
+		"node_modules/pretty-bytes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.0.0.tgz",
+			"integrity": "sha512-6UqkYefdogmzqAZWzJ7laYeJnaXDy2/J+ZqiiMtS7t7OfpXWTlaeGMwX8U6EFvPV/YWWEKRkS8hKS4k60WHTOg==",
+			"dev": true,
+			"engines": {
+				"node": "^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/process-nextick-args": {
@@ -7817,59 +7727,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/rollup-plugin-dts": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-3.0.2.tgz",
-			"integrity": "sha512-hswlsdWu/x7k5pXzaLP6OvKRKcx8Bzprksz9i9mUe72zvt8LvqAb/AZpzs6FkLgmyRaN8B6rUQOVtzA3yEt9Yw==",
-			"dev": true,
-			"dependencies": {
-				"magic-string": "^0.25.7"
-			},
-			"engines": {
-				"node": ">=v12.22.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/Swatinem"
-			},
-			"optionalDependencies": {
-				"@babel/code-frame": "^7.12.13"
-			},
-			"peerDependencies": {
-				"rollup": "^2.48.0",
-				"typescript": "^4.2.4"
-			}
-		},
-		"node_modules/rollup-plugin-esbuild": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.5.0.tgz",
-			"integrity": "sha512-ieUd3AoYWsN6Tfp0LBNnC+QpdhKjDEaH4NK3ghuEXOH56/7TAtD+hMbD9vSWZgsGSbaqCkrn4j6PaUj1vOSt1g==",
-			"dev": true,
-			"dependencies": {
-				"@rollup/pluginutils": "^4.1.0",
-				"joycon": "^3.0.1",
-				"jsonc-parser": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"esbuild": ">=0.10.1",
-				"rollup": "^1.20.0 || ^2.0.0"
-			}
-		},
-		"node_modules/rollup-plugin-esbuild/node_modules/@rollup/pluginutils": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-			"dev": true,
-			"dependencies": {
-				"estree-walker": "^2.0.1",
-				"picomatch": "^2.2.2"
-			},
-			"engines": {
-				"node": ">= 8.0.0"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7924,6 +7781,12 @@
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}
+		},
+		"node_modules/scule": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/scule/-/scule-0.3.2.tgz",
+			"integrity": "sha512-zIvPdjOH8fv8CgrPT5eqtxHQXmPNnV/vHJYffZhE43KZkvULvpCTvOt1HPlFaCZx287INL9qaqrZg34e8NgI4g==",
+			"dev": true
 		},
 		"node_modules/semver": {
 			"version": "7.3.7",
@@ -7995,51 +7858,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"node_modules/siroc": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/siroc/-/siroc-0.16.0.tgz",
-			"integrity": "sha512-BOK6Ih10CFSdq1bvvWt1ZGkvYGdKmCxPxuExYogg8lcOtsMr6ZFBuW7/U4oUJkdgXsXxFE55KCmJF1vSvOSYwA==",
-			"dev": true,
-			"dependencies": {
-				"@rollup/plugin-alias": "^3.1.5",
-				"@rollup/plugin-commonjs": "^20.0.0",
-				"@rollup/plugin-json": "^4.1.0",
-				"@rollup/plugin-node-resolve": "^13.0.4",
-				"@rollup/plugin-replace": "^3.0.0",
-				"cac": "^6.7.3",
-				"chalk": "^4.1.2",
-				"consola": "^2.15.3",
-				"defu": "^5.0.0",
-				"detect-indent": "^6.1.0",
-				"esbuild": "^0.12.22",
-				"execa": "^5.1.1",
-				"fs-extra": "^10.0.0",
-				"glob": "^7.1.7",
-				"jiti": "^1.11.0",
-				"mkdist": "^0.3.3",
-				"rollup": "^2.56.3",
-				"rollup-plugin-dts": "^3.0.2",
-				"rollup-plugin-esbuild": "4.5.0",
-				"sort-package-json": "^1.50.0",
-				"typescript": "^4.3.5",
-				"upath": "^2.0.1",
-				"v8-compile-cache": "^2.3.0"
-			},
-			"bin": {
-				"siroc": "bin/cli.js",
-				"siroc-runner": "bin/runtime.js"
-			}
-		},
-		"node_modules/siroc/node_modules/esbuild": {
-			"version": "0.12.29",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
-			"integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			}
-		},
 		"node_modules/size-limit": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.0.1.tgz",
@@ -8080,48 +7898,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/sort-object-keys": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
-			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
-			"dev": true
-		},
-		"node_modules/sort-package-json": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.57.0.tgz",
-			"integrity": "sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==",
-			"dev": true,
-			"dependencies": {
-				"detect-indent": "^6.0.0",
-				"detect-newline": "3.1.0",
-				"git-hooks-list": "1.0.3",
-				"globby": "10.0.0",
-				"is-plain-obj": "2.1.0",
-				"sort-object-keys": "^1.1.3"
-			},
-			"bin": {
-				"sort-package-json": "cli.js"
-			}
-		},
-		"node_modules/sort-package-json/node_modules/globby": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
-			"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
-			"dev": true,
-			"dependencies": {
-				"@types/glob": "^7.1.1",
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.0.3",
-				"glob": "^7.1.3",
-				"ignore": "^5.1.1",
-				"merge2": "^1.2.3",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8138,6 +7914,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/sourcemap-codec": {
@@ -8434,15 +8222,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -8529,6 +8308,26 @@
 			"dev": true,
 			"dependencies": {
 				"get-port": "^3.1.0"
+			}
+		},
+		"node_modules/terser": {
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/test-exclude": {
@@ -8780,6 +8579,12 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/ufo": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.5.tgz",
+			"integrity": "sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==",
+			"dev": true
+		},
 		"node_modules/uglify-js": {
 			"version": "3.17.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
@@ -8807,6 +8612,282 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/unbuild": {
+			"version": "0.8.9",
+			"resolved": "https://registry.npmjs.org/unbuild/-/unbuild-0.8.9.tgz",
+			"integrity": "sha512-LCFL/V3Y0UDxal6MNvSTGuyOnTAha467oTCRURZqj4zaW1r/kTDeVNkA9OdP8J/bnsxr0CvkdjRjlvv/K3o7Yw==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/plugin-alias": "^3.1.9",
+				"@rollup/plugin-commonjs": "^22.0.2",
+				"@rollup/plugin-json": "^4.1.0",
+				"@rollup/plugin-node-resolve": "^13.3.0",
+				"@rollup/plugin-replace": "^4.0.0",
+				"@rollup/pluginutils": "^4.2.1",
+				"chalk": "^5.0.1",
+				"consola": "^2.15.3",
+				"defu": "^6.1.0",
+				"esbuild": "^0.15.5",
+				"globby": "^13.1.2",
+				"hookable": "^5.1.1",
+				"jiti": "^1.14.0",
+				"magic-string": "^0.26.2",
+				"mkdirp": "^1.0.4",
+				"mkdist": "^0.3.13",
+				"mlly": "^0.5.13",
+				"mri": "^1.2.0",
+				"pathe": "^0.3.5",
+				"pkg-types": "^0.3.3",
+				"pretty-bytes": "^6.0.0",
+				"rimraf": "^3.0.2",
+				"rollup": "^2.78.0",
+				"rollup-plugin-dts": "^4.2.2",
+				"rollup-plugin-esbuild": "^4.9.3",
+				"scule": "^0.3.2",
+				"typescript": "^4.7.4",
+				"untyped": "^0.4.5"
+			},
+			"bin": {
+				"unbuild": "dist/cli.mjs"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-commonjs": {
+			"version": "22.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+			"integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.68.0"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-replace": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+			"integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^3.1.0",
+				"magic-string": "^0.25.7"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+			"dev": true
+		},
+		"node_modules/unbuild/node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
+		"node_modules/unbuild/node_modules/@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/unbuild/node_modules/chalk": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/unbuild/node_modules/defu": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.0.tgz",
+			"integrity": "sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==",
+			"dev": true
+		},
+		"node_modules/unbuild/node_modules/globby": {
+			"version": "13.1.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+			"integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+			"dev": true,
+			"dependencies": {
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.11",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/unbuild/node_modules/magic-string": {
+			"version": "0.26.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/unbuild/node_modules/pathe": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.5.tgz",
+			"integrity": "sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==",
+			"dev": true
+		},
+		"node_modules/unbuild/node_modules/resolve": {
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/unbuild/node_modules/rollup-plugin-dts": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+			"integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+			"dev": true,
+			"dependencies": {
+				"magic-string": "^0.26.1"
+			},
+			"engines": {
+				"node": ">=v12.22.11"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Swatinem"
+			},
+			"optionalDependencies": {
+				"@babel/code-frame": "^7.16.7"
+			},
+			"peerDependencies": {
+				"rollup": "^2.55",
+				"typescript": "^4.1"
+			}
+		},
+		"node_modules/unbuild/node_modules/rollup-plugin-esbuild": {
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.9.3.tgz",
+			"integrity": "sha512-bxfUNYTa9Tw/4kdFfT9gtidDtqXyRdCW11ctZM7D8houCCVqp5qHzQF7hhIr31rqMA0APbG47fgVbbCGXgM49Q==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^4.1.1",
+				"debug": "^4.3.3",
+				"es-module-lexer": "^0.9.3",
+				"joycon": "^3.0.1",
+				"jsonc-parser": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"esbuild": ">=0.10.1",
+				"rollup": "^1.20.0 || ^2.0.0"
+			}
+		},
+		"node_modules/unbuild/node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/unist-util-stringify-position": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
@@ -8829,14 +8910,16 @@
 				"node": ">= 10.0.0"
 			}
 		},
-		"node_modules/upath": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+		"node_modules/untyped": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/untyped/-/untyped-0.4.5.tgz",
+			"integrity": "sha512-buq9URfOj4xAnVfu6BYNKzHZLHAzsCbHsDc/kHy66ESMqRpj00oD9qWf2M2qm0pC0DigsVxRF3uhOa5HJtrwGA==",
 			"dev": true,
-			"engines": {
-				"node": ">=4",
-				"yarn": "*"
+			"dependencies": {
+				"@babel/core": "^7.18.10",
+				"@babel/standalone": "^7.18.11",
+				"@babel/types": "^7.18.10",
+				"scule": "^0.3.2"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -9946,6 +10029,12 @@
 			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
 			"dev": true
 		},
+		"@babel/standalone": {
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.18.13.tgz",
+			"integrity": "sha512-5hjvvFkaXyfQri+s4CAZtx6FTKclfTNd2QN2RwgzCVJhnYYgKh4YFBCnNJSxurzvpSKD2NmpCkoWAkMc+j9y+g==",
+			"dev": true
+		},
 		"@babel/template": {
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
@@ -10153,6 +10242,33 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/gen-mapping": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"dev": true,
+					"optional": true,
+					"peer": true,
+					"requires": {
+						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/sourcemap-codec": "^1.4.10",
+						"@jridgewell/trace-mapping": "^0.3.9"
+					}
+				}
+			}
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
@@ -10382,34 +10498,6 @@
 				"slash": "^3.0.0"
 			}
 		},
-		"@rollup/plugin-commonjs": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
-			"integrity": "sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==",
-			"dev": true,
-			"requires": {
-				"@rollup/pluginutils": "^3.1.0",
-				"commondir": "^1.0.1",
-				"estree-walker": "^2.0.1",
-				"glob": "^7.1.6",
-				"is-reference": "^1.2.1",
-				"magic-string": "^0.25.7",
-				"resolve": "^1.17.0"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.22.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-					"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.9.0",
-						"path-parse": "^1.0.7",
-						"supports-preserve-symlinks-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"@rollup/plugin-json": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -10444,16 +10532,6 @@
 						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
 				}
-			}
-		},
-		"@rollup/plugin-replace": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-3.1.0.tgz",
-			"integrity": "sha512-pA3XRUrSKybVYqmH5TqWNZpGxF+VV+1GrYchKgCNIj2vsSOX7CVm2RCtx8p2nrC7xvkziYyK+lSi74T93MU3YA==",
-			"dev": true,
-			"requires": {
-				"@rollup/pluginutils": "^3.1.0",
-				"magic-string": "^0.25.7"
 			}
 		},
 		"@rollup/pluginutils": {
@@ -10561,16 +10639,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
-			"dev": true,
-			"requires": {
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -10591,12 +10659,6 @@
 			"requires": {
 				"@types/unist": "*"
 			}
-		},
-		"@types/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
 		},
 		"@types/minimist": {
 			"version": "1.2.2",
@@ -11003,12 +11065,6 @@
 				"yargs-parser": "^20.2.9"
 			}
 		},
-		"cac": {
-			"version": "6.7.12",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.12.tgz",
-			"integrity": "sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==",
-			"dev": true
-		},
 		"caching-transform": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -11212,6 +11268,14 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
+		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"comment-parser": {
 			"version": "1.3.1",
@@ -11600,12 +11664,6 @@
 				"object-keys": "^1.1.1"
 			}
 		},
-		"defu": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
-			"integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
-			"dev": true
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -11776,6 +11834,12 @@
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
 			}
+		},
+		"es-module-lexer": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"dev": true
 		},
 		"es-shim-unscopables": {
 			"version": "1.0.0",
@@ -12197,23 +12261,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
-		"execa": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.0",
-				"human-signals": "^2.1.0",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.1",
-				"onetime": "^5.1.2",
-				"signal-exit": "^3.0.3",
-				"strip-final-newline": "^2.0.0"
-			}
-		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12496,12 +12543,6 @@
 			"integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
 			"dev": true
 		},
-		"get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-			"dev": true
-		},
 		"get-symbol-description": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -12510,12 +12551,6 @@
 				"call-bind": "^1.0.2",
 				"get-intrinsic": "^1.1.1"
 			}
-		},
-		"git-hooks-list": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
-			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
-			"dev": true
 		},
 		"git-raw-commits": {
 			"version": "2.0.11",
@@ -12727,6 +12762,12 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"hookable": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.2.2.tgz",
+			"integrity": "sha512-J+tYTxF7bOYEQX2MJ3jWWjAKhQLzRAf0efkxyNfuSnIFLl3AXOpkuOVpVhBx5zMSeGPzIUNN5FpYQaA1eYzfVQ==",
+			"dev": true
+		},
 		"hosted-git-info": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -12808,12 +12849,6 @@
 					"dev": true
 				}
 			}
-		},
-		"human-signals": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.6.3",
@@ -12993,12 +13028,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true
-		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 			"dev": true
 		},
 		"is-reference": {
@@ -13413,15 +13442,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dev": true,
-			"requires": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -13620,12 +13640,6 @@
 					"dev": true
 				}
 			}
-		},
-		"merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
 		},
 		"merge2": {
 			"version": "1.4.1",
@@ -13889,12 +13903,6 @@
 				"mime-db": "1.52.0"
 			}
 		},
-		"mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
-		},
 		"min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -14139,6 +14147,26 @@
 				}
 			}
 		},
+		"mlly": {
+			"version": "0.5.14",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-0.5.14.tgz",
+			"integrity": "sha512-DgRgNUSX9NIxxCxygX4Xeg9C7GX7OUx1wuQ8cXx9o9LE0e9wrH+OZ9fcnrlEedsC/rtqry3ZhUddC759XD/L0w==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.8.0",
+				"pathe": "^0.3.5",
+				"pkg-types": "^0.3.4",
+				"ufo": "^0.8.5"
+			},
+			"dependencies": {
+				"pathe": {
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.5.tgz",
+					"integrity": "sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==",
+					"dev": true
+				}
+			}
+		},
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -14260,15 +14288,6 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
-		},
-		"npm-run-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-			"dev": true,
-			"requires": {
-				"path-key": "^3.0.0"
-			}
 		},
 		"nyc": {
 			"version": "15.1.0",
@@ -14478,15 +14497,6 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"onetime": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
-			"requires": {
-				"mimic-fn": "^2.1.0"
 			}
 		},
 		"optionator": {
@@ -14701,6 +14711,25 @@
 				}
 			}
 		},
+		"pkg-types": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-0.3.4.tgz",
+			"integrity": "sha512-s214f/xkRpwlwVBToWq9Mu0XlU3HhZMYCnr2var8+jjbavBHh/VCh4pBLsJW29rJ//B1jb4HlpMIaNIMH+W2/w==",
+			"dev": true,
+			"requires": {
+				"jsonc-parser": "^3.1.0",
+				"mlly": "^0.5.13",
+				"pathe": "^0.3.5"
+			},
+			"dependencies": {
+				"pathe": {
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.5.tgz",
+					"integrity": "sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==",
+					"dev": true
+				}
+			}
+		},
 		"postcss": {
 			"version": "8.4.14",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -14742,6 +14771,12 @@
 				"comment-parser": "^1.3.1",
 				"mdast-util-from-markdown": "^1.2.0"
 			}
+		},
+		"pretty-bytes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.0.0.tgz",
+			"integrity": "sha512-6UqkYefdogmzqAZWzJ7laYeJnaXDy2/J+ZqiiMtS7t7OfpXWTlaeGMwX8U6EFvPV/YWWEKRkS8hKS4k60WHTOg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -15094,39 +15129,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"rollup-plugin-dts": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-3.0.2.tgz",
-			"integrity": "sha512-hswlsdWu/x7k5pXzaLP6OvKRKcx8Bzprksz9i9mUe72zvt8LvqAb/AZpzs6FkLgmyRaN8B6rUQOVtzA3yEt9Yw==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"magic-string": "^0.25.7"
-			}
-		},
-		"rollup-plugin-esbuild": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.5.0.tgz",
-			"integrity": "sha512-ieUd3AoYWsN6Tfp0LBNnC+QpdhKjDEaH4NK3ghuEXOH56/7TAtD+hMbD9vSWZgsGSbaqCkrn4j6PaUj1vOSt1g==",
-			"dev": true,
-			"requires": {
-				"@rollup/pluginutils": "^4.1.0",
-				"joycon": "^3.0.1",
-				"jsonc-parser": "^3.0.0"
-			},
-			"dependencies": {
-				"@rollup/pluginutils": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-					"dev": true,
-					"requires": {
-						"estree-walker": "^2.0.1",
-						"picomatch": "^2.2.2"
-					}
-				}
-			}
-		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15164,6 +15166,12 @@
 			"requires": {
 				"loose-envify": "^1.1.0"
 			}
+		},
+		"scule": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/scule/-/scule-0.3.2.tgz",
+			"integrity": "sha512-zIvPdjOH8fv8CgrPT5eqtxHQXmPNnV/vHJYffZhE43KZkvULvpCTvOt1HPlFaCZx287INL9qaqrZg34e8NgI4g==",
+			"dev": true
 		},
 		"semver": {
 			"version": "7.3.7",
@@ -15220,45 +15228,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"siroc": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/siroc/-/siroc-0.16.0.tgz",
-			"integrity": "sha512-BOK6Ih10CFSdq1bvvWt1ZGkvYGdKmCxPxuExYogg8lcOtsMr6ZFBuW7/U4oUJkdgXsXxFE55KCmJF1vSvOSYwA==",
-			"dev": true,
-			"requires": {
-				"@rollup/plugin-alias": "^3.1.5",
-				"@rollup/plugin-commonjs": "^20.0.0",
-				"@rollup/plugin-json": "^4.1.0",
-				"@rollup/plugin-node-resolve": "^13.0.4",
-				"@rollup/plugin-replace": "^3.0.0",
-				"cac": "^6.7.3",
-				"chalk": "^4.1.2",
-				"consola": "^2.15.3",
-				"defu": "^5.0.0",
-				"detect-indent": "^6.1.0",
-				"esbuild": "^0.12.22",
-				"execa": "^5.1.1",
-				"fs-extra": "^10.0.0",
-				"glob": "^7.1.7",
-				"jiti": "^1.11.0",
-				"mkdist": "^0.3.3",
-				"rollup": "^2.56.3",
-				"rollup-plugin-dts": "^3.0.2",
-				"rollup-plugin-esbuild": "4.5.0",
-				"sort-package-json": "^1.50.0",
-				"typescript": "^4.3.5",
-				"upath": "^2.0.1",
-				"v8-compile-cache": "^2.3.0"
-			},
-			"dependencies": {
-				"esbuild": {
-					"version": "0.12.29",
-					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
-					"integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
-					"dev": true
-				}
-			}
-		},
 		"size-limit": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.0.1.tgz",
@@ -15290,44 +15259,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"sort-object-keys": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
-			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
-			"dev": true
-		},
-		"sort-package-json": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.57.0.tgz",
-			"integrity": "sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==",
-			"dev": true,
-			"requires": {
-				"detect-indent": "^6.0.0",
-				"detect-newline": "3.1.0",
-				"git-hooks-list": "1.0.3",
-				"globby": "10.0.0",
-				"is-plain-obj": "2.1.0",
-				"sort-object-keys": "^1.1.3"
-			},
-			"dependencies": {
-				"globby": {
-					"version": "10.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
-					"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
-						"slash": "^3.0.0"
-					}
-				}
-			}
-		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15339,6 +15270,18 @@
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",
@@ -15579,12 +15522,6 @@
 			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
 			"dev": true
 		},
-		"strip-final-newline": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-			"dev": true
-		},
 		"strip-indent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -15637,6 +15574,20 @@
 			"dev": true,
 			"requires": {
 				"get-port": "^3.1.0"
+			}
+		},
+		"terser": {
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
 			}
 		},
 		"test-exclude": {
@@ -15840,6 +15791,12 @@
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"dev": true
 		},
+		"ufo": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.5.tgz",
+			"integrity": "sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==",
+			"dev": true
+		},
 		"uglify-js": {
 			"version": "3.17.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
@@ -15858,6 +15815,217 @@
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},
+		"unbuild": {
+			"version": "0.8.9",
+			"resolved": "https://registry.npmjs.org/unbuild/-/unbuild-0.8.9.tgz",
+			"integrity": "sha512-LCFL/V3Y0UDxal6MNvSTGuyOnTAha467oTCRURZqj4zaW1r/kTDeVNkA9OdP8J/bnsxr0CvkdjRjlvv/K3o7Yw==",
+			"dev": true,
+			"requires": {
+				"@rollup/plugin-alias": "^3.1.9",
+				"@rollup/plugin-commonjs": "^22.0.2",
+				"@rollup/plugin-json": "^4.1.0",
+				"@rollup/plugin-node-resolve": "^13.3.0",
+				"@rollup/plugin-replace": "^4.0.0",
+				"@rollup/pluginutils": "^4.2.1",
+				"chalk": "^5.0.1",
+				"consola": "^2.15.3",
+				"defu": "^6.1.0",
+				"esbuild": "^0.15.5",
+				"globby": "^13.1.2",
+				"hookable": "^5.1.1",
+				"jiti": "^1.14.0",
+				"magic-string": "^0.26.2",
+				"mkdirp": "^1.0.4",
+				"mkdist": "^0.3.13",
+				"mlly": "^0.5.13",
+				"mri": "^1.2.0",
+				"pathe": "^0.3.5",
+				"pkg-types": "^0.3.3",
+				"pretty-bytes": "^6.0.0",
+				"rimraf": "^3.0.2",
+				"rollup": "^2.78.0",
+				"rollup-plugin-dts": "^4.2.2",
+				"rollup-plugin-esbuild": "^4.9.3",
+				"scule": "^0.3.2",
+				"typescript": "^4.7.4",
+				"untyped": "^0.4.5"
+			},
+			"dependencies": {
+				"@rollup/plugin-commonjs": {
+					"version": "22.0.2",
+					"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
+					"integrity": "sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==",
+					"dev": true,
+					"requires": {
+						"@rollup/pluginutils": "^3.1.0",
+						"commondir": "^1.0.1",
+						"estree-walker": "^2.0.1",
+						"glob": "^7.1.6",
+						"is-reference": "^1.2.1",
+						"magic-string": "^0.25.7",
+						"resolve": "^1.17.0"
+					},
+					"dependencies": {
+						"@rollup/pluginutils": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+							"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+							"dev": true,
+							"requires": {
+								"@types/estree": "0.0.39",
+								"estree-walker": "^1.0.1",
+								"picomatch": "^2.2.2"
+							},
+							"dependencies": {
+								"estree-walker": {
+									"version": "1.0.1",
+									"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+									"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+									"dev": true
+								}
+							}
+						},
+						"magic-string": {
+							"version": "0.25.9",
+							"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+							"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+							"dev": true,
+							"requires": {
+								"sourcemap-codec": "^1.4.8"
+							}
+						}
+					}
+				},
+				"@rollup/plugin-replace": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+					"integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+					"dev": true,
+					"requires": {
+						"@rollup/pluginutils": "^3.1.0",
+						"magic-string": "^0.25.7"
+					},
+					"dependencies": {
+						"@rollup/pluginutils": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+							"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+							"dev": true,
+							"requires": {
+								"@types/estree": "0.0.39",
+								"estree-walker": "^1.0.1",
+								"picomatch": "^2.2.2"
+							}
+						},
+						"estree-walker": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+							"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+							"dev": true
+						},
+						"magic-string": {
+							"version": "0.25.9",
+							"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+							"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+							"dev": true,
+							"requires": {
+								"sourcemap-codec": "^1.4.8"
+							}
+						}
+					}
+				},
+				"@rollup/pluginutils": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"chalk": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+					"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+					"dev": true
+				},
+				"defu": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.0.tgz",
+					"integrity": "sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==",
+					"dev": true
+				},
+				"globby": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+					"integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+					"dev": true,
+					"requires": {
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.2.11",
+						"ignore": "^5.2.0",
+						"merge2": "^1.4.1",
+						"slash": "^4.0.0"
+					}
+				},
+				"magic-string": {
+					"version": "0.26.2",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+					"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+					"dev": true,
+					"requires": {
+						"sourcemap-codec": "^1.4.8"
+					}
+				},
+				"pathe": {
+					"version": "0.3.5",
+					"resolved": "https://registry.npmjs.org/pathe/-/pathe-0.3.5.tgz",
+					"integrity": "sha512-grU/QeYP0ChuE5kjU2/k8VtAeODzbernHlue0gTa27+ayGIu3wqYBIPGfP9r5xSqgCgDd4nWrjKXEfxMillByg==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.22.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+					"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.9.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
+					}
+				},
+				"rollup-plugin-dts": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+					"integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.16.7",
+						"magic-string": "^0.26.1"
+					}
+				},
+				"rollup-plugin-esbuild": {
+					"version": "4.9.3",
+					"resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.9.3.tgz",
+					"integrity": "sha512-bxfUNYTa9Tw/4kdFfT9gtidDtqXyRdCW11ctZM7D8houCCVqp5qHzQF7hhIr31rqMA0APbG47fgVbbCGXgM49Q==",
+					"dev": true,
+					"requires": {
+						"@rollup/pluginutils": "^4.1.1",
+						"debug": "^4.3.3",
+						"es-module-lexer": "^0.9.3",
+						"joycon": "^3.0.1",
+						"jsonc-parser": "^3.0.0"
+					}
+				},
+				"slash": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+					"dev": true
+				}
+			}
+		},
 		"unist-util-stringify-position": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
@@ -15873,11 +16041,17 @@
 			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 			"dev": true
 		},
-		"upath": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-			"dev": true
+		"untyped": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/untyped/-/untyped-0.4.5.tgz",
+			"integrity": "sha512-buq9URfOj4xAnVfu6BYNKzHZLHAzsCbHsDc/kHy66ESMqRpj00oD9qWf2M2qm0pC0DigsVxRF3uhOa5HJtrwGA==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.18.10",
+				"@babel/standalone": "^7.18.11",
+				"@babel/types": "^7.18.10",
+				"scule": "^0.3.2"
+			}
 		},
 		"update-browserslist-db": {
 			"version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.34.0",
 				"@typescript-eslint/parser": "^5.34.0",
 				"@vitest/coverage-c8": "^0.22.1",
+				"chokidar-cli": "^3.0.0",
 				"eslint": "^8.22.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-prettier": "^4.2.1",
@@ -2084,6 +2085,221 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar-cli": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+			"integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.2",
+				"lodash.debounce": "^4.0.8",
+				"lodash.throttle": "^4.1.1",
+				"yargs": "^13.3.0"
+			},
+			"bin": {
+				"chokidar": "index.js"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/ansi-regex": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/cliui": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/chokidar-cli/node_modules/emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
+		},
+		"node_modules/chokidar-cli/node_modules/find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/string-width": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^7.0.1",
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/wrap-ansi": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"dev": true
+		},
+		"node_modules/chokidar-cli/node_modules/yargs": {
+			"version": "13.3.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^5.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.2"
+			}
+		},
+		"node_modules/chokidar-cli/node_modules/yargs-parser": {
+			"version": "13.1.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
@@ -5109,6 +5325,12 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
+		"node_modules/lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"dev": true
+		},
 		"node_modules/lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5125,6 +5347,12 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
+		"node_modules/lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+			"dev": true
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
@@ -11224,6 +11452,181 @@
 				}
 			}
 		},
+		"chokidar-cli": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+			"integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+			"dev": true,
+			"requires": {
+				"chokidar": "^3.5.2",
+				"lodash.debounce": "^4.0.8",
+				"lodash.throttle": "^4.1.1",
+				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+					"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
 		"ci-job-number": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/ci-job-number/-/ci-job-number-1.2.2.tgz",
@@ -13390,6 +13793,12 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"dev": true
+		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -13406,6 +13815,12 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
+		"lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	],
 	"scripts": {
 		"build": "unbuild",
-		"dev": "chokidar src --initial --command unbuild ",
+		"dev": "chokidar src --initial --command unbuild",
 		"format": "prettier --write .",
 		"lint": "eslint --ext .js,.ts .",
 		"prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	],
 	"scripts": {
 		"build": "unbuild",
-		"dev": "unbuild --stub",
+		"dev": "chokidar src --initial --command unbuild ",
 		"format": "prettier --write .",
 		"lint": "eslint --ext .js,.ts .",
 		"prepare": "npm run build",
@@ -56,6 +56,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.34.0",
 		"@typescript-eslint/parser": "^5.34.0",
 		"@vitest/coverage-c8": "^0.22.1",
+		"chokidar-cli": "^3.0.0",
 		"eslint": "^8.22.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -15,23 +15,19 @@
 	},
 	"license": "Apache-2.0",
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",
+	"sideEffects": false,
+	"type": "module",
 	"exports": {
-		".": {
-			"require": "./dist/index.cjs",
-			"import": "./dist/index.js"
-		},
-		"./package.json": "./package.json"
+		".": "./dist/index.mjs"
 	},
-	"main": "./dist/index.cjs",
-	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
 		"src"
 	],
 	"scripts": {
-		"build": "siroc build",
-		"dev": "siroc build --watch",
+		"build": "unbuild",
+		"dev": "unbuild --stub",
 		"format": "prettier --write .",
 		"lint": "eslint --ext .js,.ts .",
 		"prepare": "npm run build",
@@ -50,7 +46,8 @@
 		"@prismicio/react": "^2.5.0",
 		"@prismicio/types": "^0.2.3",
 		"eslint-plugin-react": "^7.30.1",
-		"eslint-plugin-react-hooks": "^4.6.0"
+		"eslint-plugin-react-hooks": "^4.6.0",
+		"imgix-url-builder": "^0.0.3"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.1.1",
@@ -70,10 +67,10 @@
 		"prettier-plugin-jsdoc": "^0.3.38",
 		"react": "^18.1.0",
 		"react-test-renderer": "^18.2.0",
-		"siroc": "^0.16.0",
 		"size-limit": "^8.0.1",
 		"standard-version": "^9.5.0",
 		"typescript": "^4.7.4",
+		"unbuild": "^0.8.9",
 		"vitest": "^0.22.1"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for tree-shaking. Only used chunks (i.e. components, functions) from `@prismicio/next` are included in a Next.js app's JavaScript bundle.

Without this PR, `@prismicio/next`'s full bundle and its dependencies would be included in a Next.js app's JavaScript bundle.

To accomplish this, Rollup's [`preserveModules` option](https://rollupjs.org/guide/en/#outputpreservemodules) was enabled. This effectively disables bundling (at least in this package's case), preserving the source files (i.e. chunks). This allows Next.js's bundler to properly remove whole unused chunks from its output.

As part of this change, `siroc` was replaced by `unbuild` as a build tool. `unbuild` results in better build output.

Fixes #35 

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦤
