### PR TITLE
refactor: use `next/script` to load the Prismic Toolbar

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6,7 +6,8 @@
 		"": {
 			"name": "example",
 			"dependencies": {
-				"@prismicio/next": "latest"
+				"@prismicio/next": "latest",
+				"@prismicio/react": "^2.5.0"
 			},
 			"devDependencies": {
 				"slice-machine-ui": "^0.3.4"
@@ -2159,15 +2160,23 @@
 			}
 		},
 		"node_modules/@prismicio/helpers": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.2.1.tgz",
-			"integrity": "sha512-WFfS5CpPJ1PTNU/cqx3XnO8mnbfI8bEgAnWqD57IS5Pqy8YcK8oW5VSR7nw2wPowJjWTuf8j59YtE5uiHi6aCQ==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.5.tgz",
+			"integrity": "sha512-lL9TQG+GKtOATvLOlTFoaDfEZOgrNXHRuD+TxCSwLPKRBtYVs6zBoU6SkkcISm/DCe8PwGD0zo44zDdPtFJuBA==",
 			"dependencies": {
-				"@prismicio/richtext": "^2.0.1",
-				"@prismicio/types": "^0.1.27",
+				"@prismicio/richtext": "^2.1.1",
+				"@prismicio/types": "^0.2.3",
 				"escape-html": "^1.0.3",
 				"imgix-url-builder": "^0.0.3"
 			},
+			"engines": {
+				"node": ">=12.7.0"
+			}
+		},
+		"node_modules/@prismicio/helpers/node_modules/@prismicio/types": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.3.tgz",
+			"integrity": "sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw==",
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -2189,11 +2198,11 @@
 			}
 		},
 		"node_modules/@prismicio/react": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.2.0.tgz",
-			"integrity": "sha512-HTBhhtS5MvhmSmkV/GRUEFdFZ/0PhKNIFXMPOuNTWcnWi9Nlw3Co+jurIYUdI+mGt/nfyr4Wnj5XwO+94sBPRA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.5.0.tgz",
+			"integrity": "sha512-1EYdvoU2bpVEkmVDDVyTUK22C580tTWR96HJ9PMUex0oGeJLBAMKiRinyachN42r1uCH5nRAH54A90ZtBjjZhw==",
 			"dependencies": {
-				"@prismicio/helpers": "^2.2.1",
+				"@prismicio/helpers": "^2.3.1",
 				"@prismicio/richtext": "^2.0.1"
 			},
 			"engines": {
@@ -2210,12 +2219,20 @@
 			}
 		},
 		"node_modules/@prismicio/richtext": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.1.tgz",
-			"integrity": "sha512-sM+eusvE4PsKnwefDRd0ai3Ny59XJ54dn6xfwq0Fyqj0LAcuyB2gRjSufbIqYOZ1r4JKMQArDKrypNEcrbBFkA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.1.1.tgz",
+			"integrity": "sha512-/99JR2NUU2WV0025eAIqjd9OnF4ITaM57SVuhLc1XBUgnJe0HZrC9f24YKVW43jFR5HYTJtLgz01WjEddymqmA==",
 			"dependencies": {
-				"@prismicio/types": "^0.1.22"
+				"@prismicio/types": "^0.2.0"
 			},
+			"engines": {
+				"node": ">=12.7.0"
+			}
+		},
+		"node_modules/@prismicio/richtext/node_modules/@prismicio/types": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.3.tgz",
+			"integrity": "sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw==",
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -2224,6 +2241,7 @@
 			"version": "0.1.27",
 			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.27.tgz",
 			"integrity": "sha512-+Oc7EFcp6RGVMvFKQl9y9D4HtBhHeOtE0asfYhedCflQDf3OOzjE8POIu1bXTkk8i1kEWM3oYvz6yLN4yAyGWQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -11382,14 +11400,21 @@
 			}
 		},
 		"@prismicio/helpers": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.2.1.tgz",
-			"integrity": "sha512-WFfS5CpPJ1PTNU/cqx3XnO8mnbfI8bEgAnWqD57IS5Pqy8YcK8oW5VSR7nw2wPowJjWTuf8j59YtE5uiHi6aCQ==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.5.tgz",
+			"integrity": "sha512-lL9TQG+GKtOATvLOlTFoaDfEZOgrNXHRuD+TxCSwLPKRBtYVs6zBoU6SkkcISm/DCe8PwGD0zo44zDdPtFJuBA==",
 			"requires": {
-				"@prismicio/richtext": "^2.0.1",
-				"@prismicio/types": "^0.1.27",
+				"@prismicio/richtext": "^2.1.1",
+				"@prismicio/types": "^0.2.3",
 				"escape-html": "^1.0.3",
 				"imgix-url-builder": "^0.0.3"
+			},
+			"dependencies": {
+				"@prismicio/types": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.3.tgz",
+					"integrity": "sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw=="
+				}
 			}
 		},
 		"@prismicio/next": {
@@ -11401,26 +11426,34 @@
 			}
 		},
 		"@prismicio/react": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.2.0.tgz",
-			"integrity": "sha512-HTBhhtS5MvhmSmkV/GRUEFdFZ/0PhKNIFXMPOuNTWcnWi9Nlw3Co+jurIYUdI+mGt/nfyr4Wnj5XwO+94sBPRA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.5.0.tgz",
+			"integrity": "sha512-1EYdvoU2bpVEkmVDDVyTUK22C580tTWR96HJ9PMUex0oGeJLBAMKiRinyachN42r1uCH5nRAH54A90ZtBjjZhw==",
 			"requires": {
-				"@prismicio/helpers": "^2.2.1",
+				"@prismicio/helpers": "^2.3.1",
 				"@prismicio/richtext": "^2.0.1"
 			}
 		},
 		"@prismicio/richtext": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.1.tgz",
-			"integrity": "sha512-sM+eusvE4PsKnwefDRd0ai3Ny59XJ54dn6xfwq0Fyqj0LAcuyB2gRjSufbIqYOZ1r4JKMQArDKrypNEcrbBFkA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.1.1.tgz",
+			"integrity": "sha512-/99JR2NUU2WV0025eAIqjd9OnF4ITaM57SVuhLc1XBUgnJe0HZrC9f24YKVW43jFR5HYTJtLgz01WjEddymqmA==",
 			"requires": {
-				"@prismicio/types": "^0.1.22"
+				"@prismicio/types": "^0.2.0"
+			},
+			"dependencies": {
+				"@prismicio/types": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.3.tgz",
+					"integrity": "sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw=="
+				}
 			}
 		},
 		"@prismicio/types": {
 			"version": "0.1.27",
 			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.27.tgz",
-			"integrity": "sha512-+Oc7EFcp6RGVMvFKQl9y9D4HtBhHeOtE0asfYhedCflQDf3OOzjE8POIu1bXTkk8i1kEWM3oYvz6yLN4yAyGWQ=="
+			"integrity": "sha512-+Oc7EFcp6RGVMvFKQl9y9D4HtBhHeOtE0asfYhedCflQDf3OOzjE8POIu1bXTkk8i1kEWM3oYvz6yLN4yAyGWQ==",
+			"peer": true
 		},
 		"@sindresorhus/is": {
 			"version": "4.6.0",

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,8 @@
 		"slicemachine": "start-slicemachine"
 	},
 	"dependencies": {
-		"@prismicio/next": "latest"
+		"@prismicio/next": "latest",
+		"@prismicio/react": "^2.5.0"
 	},
 	"devDependencies": {
 		"slice-machine-ui": "^0.3.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@prismicio/client": "^6.7.1",
 				"@prismicio/helpers": "^2.3.5",
-				"@prismicio/react": "^2.5.0",
 				"@prismicio/types": "^0.2.3",
 				"imgix-url-builder": "^0.0.3"
 			},
@@ -1088,27 +1087,6 @@
 			},
 			"engines": {
 				"node": ">=12.7.0"
-			}
-		},
-		"node_modules/@prismicio/react": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.5.0.tgz",
-			"integrity": "sha512-1EYdvoU2bpVEkmVDDVyTUK22C580tTWR96HJ9PMUex0oGeJLBAMKiRinyachN42r1uCH5nRAH54A90ZtBjjZhw==",
-			"dependencies": {
-				"@prismicio/helpers": "^2.3.1",
-				"@prismicio/richtext": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=12.7.0"
-			},
-			"peerDependencies": {
-				"@prismicio/client": "^6.0.0",
-				"react": "^16.8 || ^17 || ^18"
-			},
-			"peerDependenciesMeta": {
-				"@prismicio/client": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@prismicio/richtext": {
@@ -5018,7 +4996,8 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -5270,6 +5249,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			},
@@ -7104,6 +7084,7 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -9536,15 +9517,6 @@
 				"@prismicio/types": "^0.2.0",
 				"change-case": "^4.1.2",
 				"rand-seed": "^1.0.1"
-			}
-		},
-		"@prismicio/react": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.5.0.tgz",
-			"integrity": "sha512-1EYdvoU2bpVEkmVDDVyTUK22C580tTWR96HJ9PMUex0oGeJLBAMKiRinyachN42r1uCH5nRAH54A90ZtBjjZhw==",
-			"requires": {
-				"@prismicio/helpers": "^2.3.1",
-				"@prismicio/richtext": "^2.0.1"
 			}
 		},
 		"@prismicio/richtext": {
@@ -12370,7 +12342,8 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "4.1.0",
@@ -12562,6 +12535,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -13807,6 +13781,7 @@
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -46,9 +46,8 @@
 		"unit:watch": "vitest watch"
 	},
 	"dependencies": {
-		"@prismicio/client": "^6.7.1",
+		"@prismicio/client": "^6.0.0",
 		"@prismicio/helpers": "^2.3.5",
-		"@prismicio/react": "^2.5.0",
 		"@prismicio/types": "^0.2.3",
 		"imgix-url-builder": "^0.0.3"
 	},

--- a/src/PrismicPreview.tsx
+++ b/src/PrismicPreview.tsx
@@ -166,6 +166,7 @@ export function PrismicPreview({
 			{children}
 			<Script
 				src={`https://static.cdn.prismic.io/prismic.js?repo=${repositoryName}&new=true`}
+				strategy="lazyOnload"
 			/>
 		</>
 	);

--- a/src/PrismicPreview.tsx
+++ b/src/PrismicPreview.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { PrismicToolbar } from "@prismicio/react";
 import { useRouter } from "next/router";
+import Script from "next/script";
 
 import { getPrismicPreviewCookie } from "./lib/getPrismicPreviewCookie";
 import { getPreviewCookieRepositoryName } from "./lib/getPreviewCookieRepositoryName";
@@ -164,7 +164,9 @@ export function PrismicPreview({
 	return (
 		<>
 			{children}
-			<PrismicToolbar repositoryName={repositoryName} />
+			<Script
+				src={`https://static.cdn.prismic.io/prismic.js?repo=${repositoryName}&new=true`}
+			/>
 		</>
 	);
 }

--- a/test/PrismicPreview.test.tsx
+++ b/test/PrismicPreview.test.tsx
@@ -51,8 +51,8 @@ vi.mock("next/router", () => {
 
 vi.mock("next/script", () => {
 	return {
-		default: vi.fn(() => {
-			return null;
+		default: vi.fn(({ src }: { src: string }) => {
+			return <div data-next-script={true} data-src={src} />;
 		}),
 	};
 });
@@ -79,16 +79,19 @@ afterEach(() => {
 });
 
 test("renders the Prismic toolbar for the given repository using next/script", () => {
-	const { unmount } = render(<PrismicPreview repositoryName="qwerty" />);
+	const { unmount, toJSON } = render(
+		<PrismicPreview repositoryName="qwerty" />,
+	);
+
+	const actual = toJSON();
 
 	renderer.act(() => unmount());
 
-	expect(Script).toHaveBeenCalledWith(
-		{
-			src: "https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true",
-		},
-		{},
-	);
+	const expected = render(
+		<Script src="https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true" />,
+	).toJSON();
+
+	expect(actual).toStrictEqual(expected);
 });
 
 test("calls the default preview API endpoint on prismicPreviewUpdate toolbar events", async () => {
@@ -349,7 +352,10 @@ test("renders children untouched", () => {
 	).toJSON() as renderer.ReactTestRendererJSON;
 
 	const expected = render(
-		<span>children</span>,
+		<>
+			<span>children</span>
+			<Script src="https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true" />
+		</>,
 	).toJSON() as renderer.ReactTestRendererJSON;
 
 	expect(actual).toMatchObject(expected);

--- a/test/PrismicPreview.test.tsx
+++ b/test/PrismicPreview.test.tsx
@@ -51,8 +51,10 @@ vi.mock("next/router", () => {
 
 vi.mock("next/script", () => {
 	return {
-		default: vi.fn(({ src }: { src: string }) => {
-			return <div data-next-script={true} data-src={src} />;
+		default: vi.fn(({ src, strategy }: { src: string; strategy: string }) => {
+			return (
+				<div data-next-script={true} data-src={src} data-strategy={strategy} />
+			);
 		}),
 	};
 });
@@ -88,7 +90,10 @@ test("renders the Prismic toolbar for the given repository using next/script", (
 	renderer.act(() => unmount());
 
 	const expected = render(
-		<Script src="https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true" />,
+		<Script
+			src="https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true"
+			strategy="lazyOnload"
+		/>,
 	).toJSON();
 
 	expect(actual).toStrictEqual(expected);
@@ -354,7 +359,10 @@ test("renders children untouched", () => {
 	const expected = render(
 		<>
 			<span>children</span>
-			<Script src="https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true" />
+			<Script
+				src="https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true"
+				strategy="lazyOnload"
+			/>
 		</>,
 	).toJSON() as renderer.ReactTestRendererJSON;
 

--- a/test/PrismicPreview.test.tsx
+++ b/test/PrismicPreview.test.tsx
@@ -2,6 +2,7 @@
 
 import { test, expect, beforeAll, vi, afterEach } from "vitest";
 import { NextRouter, useRouter } from "next/router";
+import Script from "next/script";
 import * as React from "react";
 import * as renderer from "react-test-renderer";
 
@@ -48,6 +49,14 @@ vi.mock("next/router", () => {
 	};
 });
 
+vi.mock("next/script", () => {
+	return {
+		default: vi.fn(() => {
+			return null;
+		}),
+	};
+});
+
 const fetch = vi.fn(async () => {
 	return {
 		ok: true,
@@ -69,20 +78,16 @@ afterEach(() => {
 	vi.mocked(useRouter).mockRestore();
 });
 
-test("renders the Prismic toolbar for the given repository", () => {
+test("renders the Prismic toolbar for the given repository using next/script", () => {
 	const { unmount } = render(<PrismicPreview repositoryName="qwerty" />);
-
-	const script = Array.from(document.querySelectorAll("script")).find(
-		(element) =>
-			element
-				.getAttribute("src")
-				?.startsWith("https://static.cdn.prismic.io/prismic.js"),
-	);
 
 	renderer.act(() => unmount());
 
-	expect(script?.getAttribute("src") || "").toMatch(
-		"https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true",
+	expect(Script).toHaveBeenCalledWith(
+		{
+			src: "https://static.cdn.prismic.io/prismic.js?repo=qwerty&new=true",
+		},
+		{},
 	);
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes `<PrismicPreview>`'s implementation to load the Prismic Toolbar from `@prismicio/react`'s `<PrismicToolbar>` to [Next.js's `next/script`](https://nextjs.org/docs/basic-features/script).

Using `next/script` optimizes external script loading to work with Next.js's hydration execution. It also allows us to remove `@prismicio/react` as a dependency.

As of this PR, `<PrismicPreview>` uses `next/script`'s `lazyOnload` loading strategy. This loads the Prismic Toolbar after higher priority resources have loaded, improving perceved performance. Because the toolbar is used primarily for previews and not critical data loading for public users, loading the toolbar slightly later should not be an issue.

Closes #39

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦥
