### PR TITLE
feat!: support Next 13, drop support for Next 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,10 +30,10 @@
 				"eslint-plugin-tsdoc": "^0.2.17",
 				"happy-dom": "^7.5.13",
 				"next": "^13.0.0",
-				"next12": "npm:next@^12.0.0",
 				"prettier": "^2.7.1",
 				"prettier-plugin-jsdoc": "^0.4.2",
 				"react": "^18.1.0",
+				"react-dom": "^18.2.0",
 				"react-test-renderer": "^18.2.0",
 				"size-limit": "^8.1.0",
 				"standard-version": "^9.5.0",
@@ -47,8 +47,8 @@
 			},
 			"peerDependencies": {
 				"@prismicio/client": "^6",
-				"next": "^11 || ^12 || ^13",
-				"react": "^17 || ^18"
+				"next": "^13",
+				"react": "^18"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -5880,294 +5880,6 @@
 				}
 			}
 		},
-		"node_modules/next12": {
-			"name": "next",
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/next/-/next-12.3.3.tgz",
-			"integrity": "sha512-Rx2Y6Wl5R8E77NOfBupp/B9OPCklqfqD0yN2+rDivhMjd6hjVFH5n0WTDI4PWwDmZsdNcYt6NV85kJ3PLR+eNQ==",
-			"dev": true,
-			"dependencies": {
-				"@next/env": "12.3.3",
-				"@swc/helpers": "0.4.11",
-				"caniuse-lite": "^1.0.30001406",
-				"postcss": "8.4.14",
-				"styled-jsx": "5.0.7",
-				"use-sync-external-store": "1.2.0"
-			},
-			"bin": {
-				"next": "dist/bin/next"
-			},
-			"engines": {
-				"node": ">=12.22.0"
-			},
-			"optionalDependencies": {
-				"@next/swc-android-arm-eabi": "12.3.3",
-				"@next/swc-android-arm64": "12.3.3",
-				"@next/swc-darwin-arm64": "12.3.3",
-				"@next/swc-darwin-x64": "12.3.3",
-				"@next/swc-freebsd-x64": "12.3.3",
-				"@next/swc-linux-arm-gnueabihf": "12.3.3",
-				"@next/swc-linux-arm64-gnu": "12.3.3",
-				"@next/swc-linux-arm64-musl": "12.3.3",
-				"@next/swc-linux-x64-gnu": "12.3.3",
-				"@next/swc-linux-x64-musl": "12.3.3",
-				"@next/swc-win32-arm64-msvc": "12.3.3",
-				"@next/swc-win32-ia32-msvc": "12.3.3",
-				"@next/swc-win32-x64-msvc": "12.3.3"
-			},
-			"peerDependencies": {
-				"fibers": ">= 3.1.0",
-				"node-sass": "^6.0.0 || ^7.0.0",
-				"react": "^17.0.2 || ^18.0.0-0",
-				"react-dom": "^17.0.2 || ^18.0.0-0",
-				"sass": "^1.3.0"
-			},
-			"peerDependenciesMeta": {
-				"fibers": {
-					"optional": true
-				},
-				"node-sass": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/next12/node_modules/@next/env": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.3.tgz",
-			"integrity": "sha512-H2pKuOasV9RgvVaWosB2rGSNeQShQpiDaF4EEjLyagIc3HwqdOw2/VAG/8Lq+adOwPv2P73O1hulTNad3k5MDw==",
-			"dev": true
-		},
-		"node_modules/next12/node_modules/@next/swc-android-arm-eabi": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.3.tgz",
-			"integrity": "sha512-5O/ZIX6hlIRGMy1R2f/8WiCZ4Hp4WTC0FcTuz8ycQ28j/mzDnmzjVoayVVr+ZmfEKQayFrRu+vxHjFyY0JGQlQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-android-arm64": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.3.tgz",
-			"integrity": "sha512-2QWreRmlxYRDtnLYn+BI8oukHwcP7W0zGIY5R2mEXRjI4ARqCLdu8RmcT9Vemw7RfeAVKA/4cv/9PY0pCcQpNA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-darwin-arm64": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.3.tgz",
-			"integrity": "sha512-GtZdDLerM+VToCMFp+W+WhnT6sxHePQH4xZZiYD/Y8KFiwHbDRcJr2FPG0bAJnGNiSvv/QQnBq74wjZ9+7vhcQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-darwin-x64": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.3.tgz",
-			"integrity": "sha512-gRYvTKrRYynjFQUDJ+upHMcBiNz0ii0m7zGgmUTlTSmrBWqVSzx79EHYT7Nn4GWHM+a/W+2VXfu+lqHcJeQ9gQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-freebsd-x64": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.3.tgz",
-			"integrity": "sha512-r+GLATzCjjQI82bgrIPXWEYBwZonSO64OThk5wU6HduZlDYTEDxZsFNoNoesCDWCgRrgg+OXj7WLNy1WlvfX7w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-linux-arm-gnueabihf": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.3.tgz",
-			"integrity": "sha512-juvRj1QX9jmQScL4nV0rROtYUFgWP76zfdn1fdfZ2BhvwUugIAq8x+jLVGlnXKUhDrP9+RrAufqXjjVkK+uBxA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.3.tgz",
-			"integrity": "sha512-hzinybStPB+SzS68hR5rzOngOH7Yd/jFuWGeg9qS5WifYXHpqwGH2BQeKpjVV0iJuyO9r309JKrRWMrbfhnuBA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-linux-arm64-musl": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.3.tgz",
-			"integrity": "sha512-oyfQYljCwf+9zUu1YkTZbRbyxmcHzvJPMGOxC3kJOReh3kCUoGcmvAxUPMtFD6FSYjJ+eaog4+2IFHtYuAw/bQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-linux-x64-gnu": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.3.tgz",
-			"integrity": "sha512-epv4FMazj/XG70KTTnrZ0H1VtL6DeWOvyHLHYy7f5PdgDpBXpDTFjVqhP8NFNH8HmaDDdeL1NvQD07AXhyvUKA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-linux-x64-musl": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.3.tgz",
-			"integrity": "sha512-bG5QODFy59XnSFTiPyIAt+rbPdphtvQMibtOVvyjwIwsBUw7swJ6k+6PSPVYEYpi6SHzi3qYBsro39ayGJKQJg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.3.tgz",
-			"integrity": "sha512-FbnT3reJ3MbTJ5W0hvlCCGGVDSpburzT5XGC9ljBJ4kr+85iNTLjv7+vrPeDdwHEqtGmdZgnabkLVCI4yFyCag==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.3.tgz",
-			"integrity": "sha512-M/fKZC2tMGWA6eTsIniNEBpx2prdR8lIxvSO3gv5P6ymZOGVWCvEMksnTkPAjHnU6d8r8eCiuGKm3UNo7zCTpQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/@next/swc-win32-x64-msvc": {
-			"version": "12.3.3",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.3.tgz",
-			"integrity": "sha512-Ku9mfGwmNtk44o4B/jEWUxBAT4tJ3S7QbBMLJdL1GmtRZ05LGL36OqWjLvBPr8dFiHOQQbYoAmYfQw7zeGypYA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/next12/node_modules/styled-jsx": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-			"integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"peerDependencies": {
-				"react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"babel-plugin-macros": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -6727,7 +6439,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
 			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
@@ -12437,139 +12148,6 @@
 				"use-sync-external-store": "1.2.0"
 			}
 		},
-		"next12": {
-			"version": "npm:next@12.3.3",
-			"resolved": "https://registry.npmjs.org/next/-/next-12.3.3.tgz",
-			"integrity": "sha512-Rx2Y6Wl5R8E77NOfBupp/B9OPCklqfqD0yN2+rDivhMjd6hjVFH5n0WTDI4PWwDmZsdNcYt6NV85kJ3PLR+eNQ==",
-			"dev": true,
-			"requires": {
-				"@next/env": "12.3.3",
-				"@next/swc-android-arm-eabi": "12.3.3",
-				"@next/swc-android-arm64": "12.3.3",
-				"@next/swc-darwin-arm64": "12.3.3",
-				"@next/swc-darwin-x64": "12.3.3",
-				"@next/swc-freebsd-x64": "12.3.3",
-				"@next/swc-linux-arm-gnueabihf": "12.3.3",
-				"@next/swc-linux-arm64-gnu": "12.3.3",
-				"@next/swc-linux-arm64-musl": "12.3.3",
-				"@next/swc-linux-x64-gnu": "12.3.3",
-				"@next/swc-linux-x64-musl": "12.3.3",
-				"@next/swc-win32-arm64-msvc": "12.3.3",
-				"@next/swc-win32-ia32-msvc": "12.3.3",
-				"@next/swc-win32-x64-msvc": "12.3.3",
-				"@swc/helpers": "0.4.11",
-				"caniuse-lite": "^1.0.30001406",
-				"postcss": "8.4.14",
-				"styled-jsx": "5.0.7",
-				"use-sync-external-store": "1.2.0"
-			},
-			"dependencies": {
-				"@next/env": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.3.tgz",
-					"integrity": "sha512-H2pKuOasV9RgvVaWosB2rGSNeQShQpiDaF4EEjLyagIc3HwqdOw2/VAG/8Lq+adOwPv2P73O1hulTNad3k5MDw==",
-					"dev": true
-				},
-				"@next/swc-android-arm-eabi": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.3.tgz",
-					"integrity": "sha512-5O/ZIX6hlIRGMy1R2f/8WiCZ4Hp4WTC0FcTuz8ycQ28j/mzDnmzjVoayVVr+ZmfEKQayFrRu+vxHjFyY0JGQlQ==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-android-arm64": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.3.tgz",
-					"integrity": "sha512-2QWreRmlxYRDtnLYn+BI8oukHwcP7W0zGIY5R2mEXRjI4ARqCLdu8RmcT9Vemw7RfeAVKA/4cv/9PY0pCcQpNA==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-darwin-arm64": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.3.tgz",
-					"integrity": "sha512-GtZdDLerM+VToCMFp+W+WhnT6sxHePQH4xZZiYD/Y8KFiwHbDRcJr2FPG0bAJnGNiSvv/QQnBq74wjZ9+7vhcQ==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-darwin-x64": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.3.tgz",
-					"integrity": "sha512-gRYvTKrRYynjFQUDJ+upHMcBiNz0ii0m7zGgmUTlTSmrBWqVSzx79EHYT7Nn4GWHM+a/W+2VXfu+lqHcJeQ9gQ==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-freebsd-x64": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.3.tgz",
-					"integrity": "sha512-r+GLATzCjjQI82bgrIPXWEYBwZonSO64OThk5wU6HduZlDYTEDxZsFNoNoesCDWCgRrgg+OXj7WLNy1WlvfX7w==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-linux-arm-gnueabihf": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.3.tgz",
-					"integrity": "sha512-juvRj1QX9jmQScL4nV0rROtYUFgWP76zfdn1fdfZ2BhvwUugIAq8x+jLVGlnXKUhDrP9+RrAufqXjjVkK+uBxA==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-linux-arm64-gnu": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.3.tgz",
-					"integrity": "sha512-hzinybStPB+SzS68hR5rzOngOH7Yd/jFuWGeg9qS5WifYXHpqwGH2BQeKpjVV0iJuyO9r309JKrRWMrbfhnuBA==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-linux-arm64-musl": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.3.tgz",
-					"integrity": "sha512-oyfQYljCwf+9zUu1YkTZbRbyxmcHzvJPMGOxC3kJOReh3kCUoGcmvAxUPMtFD6FSYjJ+eaog4+2IFHtYuAw/bQ==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-linux-x64-gnu": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.3.tgz",
-					"integrity": "sha512-epv4FMazj/XG70KTTnrZ0H1VtL6DeWOvyHLHYy7f5PdgDpBXpDTFjVqhP8NFNH8HmaDDdeL1NvQD07AXhyvUKA==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-linux-x64-musl": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.3.tgz",
-					"integrity": "sha512-bG5QODFy59XnSFTiPyIAt+rbPdphtvQMibtOVvyjwIwsBUw7swJ6k+6PSPVYEYpi6SHzi3qYBsro39ayGJKQJg==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-win32-arm64-msvc": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.3.tgz",
-					"integrity": "sha512-FbnT3reJ3MbTJ5W0hvlCCGGVDSpburzT5XGC9ljBJ4kr+85iNTLjv7+vrPeDdwHEqtGmdZgnabkLVCI4yFyCag==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-win32-ia32-msvc": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.3.tgz",
-					"integrity": "sha512-M/fKZC2tMGWA6eTsIniNEBpx2prdR8lIxvSO3gv5P6ymZOGVWCvEMksnTkPAjHnU6d8r8eCiuGKm3UNo7zCTpQ==",
-					"dev": true,
-					"optional": true
-				},
-				"@next/swc-win32-x64-msvc": {
-					"version": "12.3.3",
-					"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.3.tgz",
-					"integrity": "sha512-Ku9mfGwmNtk44o4B/jEWUxBAT4tJ3S7QbBMLJdL1GmtRZ05LGL36OqWjLvBPr8dFiHOQQbYoAmYfQw7zeGypYA==",
-					"dev": true,
-					"optional": true
-				},
-				"styled-jsx": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-					"integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
-					"dev": true,
-					"requires": {}
-				}
-			}
-		},
 		"no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -12964,7 +12542,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
 			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"eslint-plugin-react-hooks": "^4.6.0",
 				"eslint-plugin-tsdoc": "^0.2.17",
 				"happy-dom": "^7.5.13",
-				"next": "^12.1.4",
+				"next": "^13.0.0",
 				"nyc": "^15.1.0",
 				"prettier": "^2.7.1",
 				"prettier-plugin-jsdoc": "^0.4.2",
@@ -47,7 +47,7 @@
 			},
 			"peerDependencies": {
 				"@prismicio/client": "^6.0.0",
-				"next": "^11 || ^12",
+				"next": "^11 || ^12 | ^13",
 				"react": "^17 || ^18"
 			}
 		},
@@ -801,15 +801,15 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
-			"integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.0.tgz",
+			"integrity": "sha512-65v9BVuah2Mplohm4+efsKEnoEuhmlGm8B2w6vD1geeEP2wXtlSJCvR/cCRJ3fD8wzCQBV41VcMBQeYET6MRkg==",
 			"dev": true
 		},
 		"node_modules/@next/swc-android-arm-eabi": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-			"integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.0.tgz",
+			"integrity": "sha512-+DUQkYF93gxFjWY+CYWE1QDX6gTgnUiWf+W4UqZjM1Jcef8U97fS6xYh+i+8rH4MM0AXHm7OSakvfOMzmjU6VA==",
 			"cpu": [
 				"arm"
 			],
@@ -823,9 +823,9 @@
 			}
 		},
 		"node_modules/@next/swc-android-arm64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-			"integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.0.tgz",
+			"integrity": "sha512-RW9Uy3bMSc0zVGCa11klFuwfP/jdcdkhdruqnrJ7v+7XHm6OFKkSRzX6ee7yGR1rdDZvTnP4GZSRSpzjLv/N0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -839,9 +839,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
-			"integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.0.tgz",
+			"integrity": "sha512-APA26nps1j4qyhOIzkclW/OmgotVHj1jBxebSpMCPw2rXfiNvKNY9FA0TcuwPmUCNqaTnm703h6oW4dvp73A4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -855,9 +855,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-			"integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.0.tgz",
+			"integrity": "sha512-qsUhUdoFuRJiaJ7LnvTQ6GZv1QnMDcRXCIjxaN0FNVXwrjkq++U7KjBUaxXkRzLV4C7u0NHLNOp0iZwNNE7ypw==",
 			"cpu": [
 				"x64"
 			],
@@ -871,9 +871,9 @@
 			}
 		},
 		"node_modules/@next/swc-freebsd-x64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-			"integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.0.tgz",
+			"integrity": "sha512-sCdyCbboS7CwdnevKH9J6hkJI76LUw1jVWt4eV7kISuLiPba3JmehZSWm80oa4ADChRVAwzhLAo2zJaYRrInbg==",
 			"cpu": [
 				"x64"
 			],
@@ -887,9 +887,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm-gnueabihf": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-			"integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.0.tgz",
+			"integrity": "sha512-/X/VxfFA41C9jrEv+sUsPLQ5vbDPVIgG0CJrzKvrcc+b+4zIgPgtfsaWq9ockjHFQi3ycvlZK4TALOXO8ovQ6Q==",
 			"cpu": [
 				"arm"
 			],
@@ -903,9 +903,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-			"integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.0.tgz",
+			"integrity": "sha512-x6Oxr1GIi0ZtNiT6jbw+JVcbEi3UQgF7mMmkrgfL4mfchOwXtWSHKTSSPnwoJWJfXYa0Vy1n8NElWNTGAqoWFw==",
 			"cpu": [
 				"arm64"
 			],
@@ -919,9 +919,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-			"integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.0.tgz",
+			"integrity": "sha512-SnMH9ngI+ipGh3kqQ8+mDtWunirwmhQnQeZkEq9e/9Xsgjf04OetqrqRHKM1HmJtG2qMUJbyXFJ0F81TPuT+3g==",
 			"cpu": [
 				"arm64"
 			],
@@ -935,9 +935,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-			"integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.0.tgz",
+			"integrity": "sha512-VSQwTX9EmdbotArtA1J67X8964oQfe0xHb32x4tu+JqTR+wOHyG6wGzPMdXH2oKAp6rdd7BzqxUXXf0J+ypHlw==",
 			"cpu": [
 				"x64"
 			],
@@ -951,9 +951,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-			"integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.0.tgz",
+			"integrity": "sha512-xBCP0nnpO0q4tsytXkvIwWFINtbFRyVY5gxa1zB0vlFtqYR9lNhrOwH3CBrks3kkeaePOXd611+8sjdUtrLnXA==",
 			"cpu": [
 				"x64"
 			],
@@ -967,9 +967,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-			"integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.0.tgz",
+			"integrity": "sha512-NutwDafqhGxqPj/eiUixJq9ImS/0sgx6gqlD7jRndCvQ2Q8AvDdu1+xKcGWGNnhcDsNM/n1avf1e62OG1GaqJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -983,9 +983,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-			"integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.0.tgz",
+			"integrity": "sha512-zNaxaO+Kl/xNz02E9QlcVz0pT4MjkXGDLb25qxtAzyJL15aU0+VjjbIZAYWctG59dvggNIUNDWgoBeVTKB9xLg==",
 			"cpu": [
 				"ia32"
 			],
@@ -999,9 +999,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-			"integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.0.tgz",
+			"integrity": "sha512-FFOGGWwTCRMu9W7MF496Urefxtuo2lttxF1vwS+1rIRsKvuLrWhVaVTj3T8sf2EBL6gtJbmh4TYlizS+obnGKA==",
 			"cpu": [
 				"x64"
 			],
@@ -2119,6 +2119,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/client-only": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+			"dev": true
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -6177,44 +6183,44 @@
 			"dev": true
 		},
 		"node_modules/next": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
-			"integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/next/-/next-13.0.0.tgz",
+			"integrity": "sha512-puH1WGM6rGeFOoFdXXYfUxN9Sgi4LMytCV5HkQJvVUOhHfC1DoVqOfvzaEteyp6P04IW+gbtK2Q9pInVSrltPA==",
 			"dev": true,
 			"dependencies": {
-				"@next/env": "12.3.1",
+				"@next/env": "13.0.0",
 				"@swc/helpers": "0.4.11",
 				"caniuse-lite": "^1.0.30001406",
 				"postcss": "8.4.14",
-				"styled-jsx": "5.0.7",
+				"styled-jsx": "5.1.0",
 				"use-sync-external-store": "1.2.0"
 			},
 			"bin": {
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": ">=12.22.0"
+				"node": ">=14.6.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-android-arm-eabi": "12.3.1",
-				"@next/swc-android-arm64": "12.3.1",
-				"@next/swc-darwin-arm64": "12.3.1",
-				"@next/swc-darwin-x64": "12.3.1",
-				"@next/swc-freebsd-x64": "12.3.1",
-				"@next/swc-linux-arm-gnueabihf": "12.3.1",
-				"@next/swc-linux-arm64-gnu": "12.3.1",
-				"@next/swc-linux-arm64-musl": "12.3.1",
-				"@next/swc-linux-x64-gnu": "12.3.1",
-				"@next/swc-linux-x64-musl": "12.3.1",
-				"@next/swc-win32-arm64-msvc": "12.3.1",
-				"@next/swc-win32-ia32-msvc": "12.3.1",
-				"@next/swc-win32-x64-msvc": "12.3.1"
+				"@next/swc-android-arm-eabi": "13.0.0",
+				"@next/swc-android-arm64": "13.0.0",
+				"@next/swc-darwin-arm64": "13.0.0",
+				"@next/swc-darwin-x64": "13.0.0",
+				"@next/swc-freebsd-x64": "13.0.0",
+				"@next/swc-linux-arm-gnueabihf": "13.0.0",
+				"@next/swc-linux-arm64-gnu": "13.0.0",
+				"@next/swc-linux-arm64-musl": "13.0.0",
+				"@next/swc-linux-x64-gnu": "13.0.0",
+				"@next/swc-linux-x64-musl": "13.0.0",
+				"@next/swc-win32-arm64-msvc": "13.0.0",
+				"@next/swc-win32-ia32-msvc": "13.0.0",
+				"@next/swc-win32-x64-msvc": "13.0.0"
 			},
 			"peerDependencies": {
 				"fibers": ">= 3.1.0",
 				"node-sass": "^6.0.0 || ^7.0.0",
-				"react": "^17.0.2 || ^18.0.0-0",
-				"react-dom": "^17.0.2 || ^18.0.0-0",
+				"react": "^18.0.0-0",
+				"react-dom": "^18.0.0-0",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
@@ -7941,10 +7947,13 @@
 			}
 		},
 		"node_modules/styled-jsx": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-			"integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+			"integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
 			"dev": true,
+			"dependencies": {
+				"client-only": "0.0.1"
+			},
 			"engines": {
 				"node": ">= 12.0.0"
 			},
@@ -9373,99 +9382,99 @@
 			}
 		},
 		"@next/env": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
-			"integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.0.tgz",
+			"integrity": "sha512-65v9BVuah2Mplohm4+efsKEnoEuhmlGm8B2w6vD1geeEP2wXtlSJCvR/cCRJ3fD8wzCQBV41VcMBQeYET6MRkg==",
 			"dev": true
 		},
 		"@next/swc-android-arm-eabi": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-			"integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.0.tgz",
+			"integrity": "sha512-+DUQkYF93gxFjWY+CYWE1QDX6gTgnUiWf+W4UqZjM1Jcef8U97fS6xYh+i+8rH4MM0AXHm7OSakvfOMzmjU6VA==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-android-arm64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-			"integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.0.tgz",
+			"integrity": "sha512-RW9Uy3bMSc0zVGCa11klFuwfP/jdcdkhdruqnrJ7v+7XHm6OFKkSRzX6ee7yGR1rdDZvTnP4GZSRSpzjLv/N0g==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-darwin-arm64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
-			"integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.0.tgz",
+			"integrity": "sha512-APA26nps1j4qyhOIzkclW/OmgotVHj1jBxebSpMCPw2rXfiNvKNY9FA0TcuwPmUCNqaTnm703h6oW4dvp73A4Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-darwin-x64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-			"integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.0.tgz",
+			"integrity": "sha512-qsUhUdoFuRJiaJ7LnvTQ6GZv1QnMDcRXCIjxaN0FNVXwrjkq++U7KjBUaxXkRzLV4C7u0NHLNOp0iZwNNE7ypw==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-freebsd-x64": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-			"integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.0.tgz",
+			"integrity": "sha512-sCdyCbboS7CwdnevKH9J6hkJI76LUw1jVWt4eV7kISuLiPba3JmehZSWm80oa4ADChRVAwzhLAo2zJaYRrInbg==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-arm-gnueabihf": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-			"integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.0.tgz",
+			"integrity": "sha512-/X/VxfFA41C9jrEv+sUsPLQ5vbDPVIgG0CJrzKvrcc+b+4zIgPgtfsaWq9ockjHFQi3ycvlZK4TALOXO8ovQ6Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-arm64-gnu": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-			"integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.0.tgz",
+			"integrity": "sha512-x6Oxr1GIi0ZtNiT6jbw+JVcbEi3UQgF7mMmkrgfL4mfchOwXtWSHKTSSPnwoJWJfXYa0Vy1n8NElWNTGAqoWFw==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-arm64-musl": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-			"integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.0.tgz",
+			"integrity": "sha512-SnMH9ngI+ipGh3kqQ8+mDtWunirwmhQnQeZkEq9e/9Xsgjf04OetqrqRHKM1HmJtG2qMUJbyXFJ0F81TPuT+3g==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-x64-gnu": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-			"integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.0.tgz",
+			"integrity": "sha512-VSQwTX9EmdbotArtA1J67X8964oQfe0xHb32x4tu+JqTR+wOHyG6wGzPMdXH2oKAp6rdd7BzqxUXXf0J+ypHlw==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-x64-musl": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-			"integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.0.tgz",
+			"integrity": "sha512-xBCP0nnpO0q4tsytXkvIwWFINtbFRyVY5gxa1zB0vlFtqYR9lNhrOwH3CBrks3kkeaePOXd611+8sjdUtrLnXA==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-win32-arm64-msvc": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-			"integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.0.tgz",
+			"integrity": "sha512-NutwDafqhGxqPj/eiUixJq9ImS/0sgx6gqlD7jRndCvQ2Q8AvDdu1+xKcGWGNnhcDsNM/n1avf1e62OG1GaqJg==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-win32-ia32-msvc": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-			"integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.0.tgz",
+			"integrity": "sha512-zNaxaO+Kl/xNz02E9QlcVz0pT4MjkXGDLb25qxtAzyJL15aU0+VjjbIZAYWctG59dvggNIUNDWgoBeVTKB9xLg==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-win32-x64-msvc": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-			"integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.0.tgz",
+			"integrity": "sha512-FFOGGWwTCRMu9W7MF496Urefxtuo2lttxF1vwS+1rIRsKvuLrWhVaVTj3T8sf2EBL6gtJbmh4TYlizS+obnGKA==",
 			"dev": true,
 			"optional": true
 		},
@@ -10278,6 +10287,12 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
+		},
+		"client-only": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
 			"dev": true
 		},
 		"cliui": {
@@ -13137,29 +13152,29 @@
 			"dev": true
 		},
 		"next": {
-			"version": "12.3.1",
-			"resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
-			"integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/next/-/next-13.0.0.tgz",
+			"integrity": "sha512-puH1WGM6rGeFOoFdXXYfUxN9Sgi4LMytCV5HkQJvVUOhHfC1DoVqOfvzaEteyp6P04IW+gbtK2Q9pInVSrltPA==",
 			"dev": true,
 			"requires": {
-				"@next/env": "12.3.1",
-				"@next/swc-android-arm-eabi": "12.3.1",
-				"@next/swc-android-arm64": "12.3.1",
-				"@next/swc-darwin-arm64": "12.3.1",
-				"@next/swc-darwin-x64": "12.3.1",
-				"@next/swc-freebsd-x64": "12.3.1",
-				"@next/swc-linux-arm-gnueabihf": "12.3.1",
-				"@next/swc-linux-arm64-gnu": "12.3.1",
-				"@next/swc-linux-arm64-musl": "12.3.1",
-				"@next/swc-linux-x64-gnu": "12.3.1",
-				"@next/swc-linux-x64-musl": "12.3.1",
-				"@next/swc-win32-arm64-msvc": "12.3.1",
-				"@next/swc-win32-ia32-msvc": "12.3.1",
-				"@next/swc-win32-x64-msvc": "12.3.1",
+				"@next/env": "13.0.0",
+				"@next/swc-android-arm-eabi": "13.0.0",
+				"@next/swc-android-arm64": "13.0.0",
+				"@next/swc-darwin-arm64": "13.0.0",
+				"@next/swc-darwin-x64": "13.0.0",
+				"@next/swc-freebsd-x64": "13.0.0",
+				"@next/swc-linux-arm-gnueabihf": "13.0.0",
+				"@next/swc-linux-arm64-gnu": "13.0.0",
+				"@next/swc-linux-arm64-musl": "13.0.0",
+				"@next/swc-linux-x64-gnu": "13.0.0",
+				"@next/swc-linux-x64-musl": "13.0.0",
+				"@next/swc-win32-arm64-msvc": "13.0.0",
+				"@next/swc-win32-ia32-msvc": "13.0.0",
+				"@next/swc-win32-x64-msvc": "13.0.0",
 				"@swc/helpers": "0.4.11",
 				"caniuse-lite": "^1.0.30001406",
 				"postcss": "8.4.14",
-				"styled-jsx": "5.0.7",
+				"styled-jsx": "5.1.0",
 				"use-sync-external-store": "1.2.0"
 			}
 		},
@@ -14439,11 +14454,13 @@
 			}
 		},
 		"styled-jsx": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-			"integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+			"integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
 			"dev": true,
-			"requires": {}
+			"requires": {
+				"client-only": "0.0.1"
+			}
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 			},
 			"peerDependencies": {
 				"@prismicio/client": "^6.0.0",
-				"next": "^11 || ^12 | ^13",
+				"next": "^11 || ^12 || ^13",
 				"react": "^17 || ^18"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"eslint-plugin-tsdoc": "^0.2.17",
 				"happy-dom": "^7.5.13",
 				"next": "^13.0.0",
-				"nyc": "^15.1.0",
+				"next12": "npm:next@^12.0.0",
 				"prettier": "^2.7.1",
 				"prettier-plugin-jsdoc": "^0.4.2",
 				"react": "^18.1.0",
@@ -612,105 +612,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^5.3.1",
-				"find-up": "^4.1.0",
-				"get-package-type": "^0.1.0",
-				"js-yaml": "^3.13.1",
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/@istanbuljs/schema": {
@@ -1609,19 +1510,6 @@
 			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
 			"dev": true
 		},
-		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dev": true,
-			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1671,24 +1559,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/append-transform": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-			"dev": true,
-			"dependencies": {
-				"default-require-extensions": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/archy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
-			"dev": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -1888,21 +1758,6 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
-			}
-		},
-		"node_modules/caching-transform": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-			"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
-			"dev": true,
-			"dependencies": {
-				"hasha": "^5.0.0",
-				"make-dir": "^3.0.0",
-				"package-hash": "^4.0.0",
-				"write-file-atomic": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/call-bind": {
@@ -2112,15 +1967,6 @@
 			"integrity": "sha512-CLOGsVDrVamzv8sXJGaILUVI6dsuAkouJP/n6t+OxLPeeA4DDby7zn9SB6EUpa1H7oIKoE+rMmkW80zYsFfUjA==",
 			"dev": true
 		},
-		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2173,12 +2019,6 @@
 			"engines": {
 				"node": ">= 12.0.0"
 			}
-		},
-		"node_modules/commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-			"dev": true
 		},
 		"node_modules/compare-func": {
 			"version": "2.0.0",
@@ -2618,21 +2458,6 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
-		"node_modules/default-require-extensions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
-			"integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
-			"dev": true,
-			"dependencies": {
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/define-properties": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -2904,12 +2729,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
 		},
 		"node_modules/esbuild": {
 			"version": "0.15.10",
@@ -3647,19 +3466,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/esquery": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -3808,23 +3614,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-			"dev": true,
-			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-			}
-		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3886,26 +3675,6 @@
 			"engines": {
 				"node": ">= 0.12"
 			}
-		},
-		"node_modules/fromentries": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
 		},
 		"node_modules/fs-extra": {
 			"version": "10.1.0",
@@ -4013,15 +3782,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-package-type": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/get-pkg-repo": {
@@ -4358,22 +4118,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasha": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-			"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-			"dev": true,
-			"dependencies": {
-				"is-stream": "^2.0.0",
-				"type-fest": "^0.8.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/he": {
@@ -4778,18 +4522,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-string": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -4832,12 +4564,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-			"dev": true
-		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -4848,15 +4574,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/isarray": {
@@ -4876,59 +4593,6 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
 			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
 			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-hook": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-			"dev": true,
-			"dependencies": {
-				"append-transform": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-instrument": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.7.5",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.0.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/istanbul-lib-processinfo": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
-			"integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
-			"dev": true,
-			"dependencies": {
-				"archy": "^1.0.0",
-				"cross-spawn": "^7.0.3",
-				"istanbul-lib-coverage": "^3.2.0",
-				"p-map": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"uuid": "^8.3.2"
-			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -4966,20 +4630,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-reports": {
@@ -5239,12 +4889,6 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
 			"dev": true
 		},
 		"node_modules/lodash.ismatch": {
@@ -6236,6 +5880,294 @@
 				}
 			}
 		},
+		"node_modules/next12": {
+			"name": "next",
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/next/-/next-12.3.3.tgz",
+			"integrity": "sha512-Rx2Y6Wl5R8E77NOfBupp/B9OPCklqfqD0yN2+rDivhMjd6hjVFH5n0WTDI4PWwDmZsdNcYt6NV85kJ3PLR+eNQ==",
+			"dev": true,
+			"dependencies": {
+				"@next/env": "12.3.3",
+				"@swc/helpers": "0.4.11",
+				"caniuse-lite": "^1.0.30001406",
+				"postcss": "8.4.14",
+				"styled-jsx": "5.0.7",
+				"use-sync-external-store": "1.2.0"
+			},
+			"bin": {
+				"next": "dist/bin/next"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			},
+			"optionalDependencies": {
+				"@next/swc-android-arm-eabi": "12.3.3",
+				"@next/swc-android-arm64": "12.3.3",
+				"@next/swc-darwin-arm64": "12.3.3",
+				"@next/swc-darwin-x64": "12.3.3",
+				"@next/swc-freebsd-x64": "12.3.3",
+				"@next/swc-linux-arm-gnueabihf": "12.3.3",
+				"@next/swc-linux-arm64-gnu": "12.3.3",
+				"@next/swc-linux-arm64-musl": "12.3.3",
+				"@next/swc-linux-x64-gnu": "12.3.3",
+				"@next/swc-linux-x64-musl": "12.3.3",
+				"@next/swc-win32-arm64-msvc": "12.3.3",
+				"@next/swc-win32-ia32-msvc": "12.3.3",
+				"@next/swc-win32-x64-msvc": "12.3.3"
+			},
+			"peerDependencies": {
+				"fibers": ">= 3.1.0",
+				"node-sass": "^6.0.0 || ^7.0.0",
+				"react": "^17.0.2 || ^18.0.0-0",
+				"react-dom": "^17.0.2 || ^18.0.0-0",
+				"sass": "^1.3.0"
+			},
+			"peerDependenciesMeta": {
+				"fibers": {
+					"optional": true
+				},
+				"node-sass": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/next12/node_modules/@next/env": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.3.tgz",
+			"integrity": "sha512-H2pKuOasV9RgvVaWosB2rGSNeQShQpiDaF4EEjLyagIc3HwqdOw2/VAG/8Lq+adOwPv2P73O1hulTNad3k5MDw==",
+			"dev": true
+		},
+		"node_modules/next12/node_modules/@next/swc-android-arm-eabi": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.3.tgz",
+			"integrity": "sha512-5O/ZIX6hlIRGMy1R2f/8WiCZ4Hp4WTC0FcTuz8ycQ28j/mzDnmzjVoayVVr+ZmfEKQayFrRu+vxHjFyY0JGQlQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-android-arm64": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.3.tgz",
+			"integrity": "sha512-2QWreRmlxYRDtnLYn+BI8oukHwcP7W0zGIY5R2mEXRjI4ARqCLdu8RmcT9Vemw7RfeAVKA/4cv/9PY0pCcQpNA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-darwin-arm64": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.3.tgz",
+			"integrity": "sha512-GtZdDLerM+VToCMFp+W+WhnT6sxHePQH4xZZiYD/Y8KFiwHbDRcJr2FPG0bAJnGNiSvv/QQnBq74wjZ9+7vhcQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-darwin-x64": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.3.tgz",
+			"integrity": "sha512-gRYvTKrRYynjFQUDJ+upHMcBiNz0ii0m7zGgmUTlTSmrBWqVSzx79EHYT7Nn4GWHM+a/W+2VXfu+lqHcJeQ9gQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-freebsd-x64": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.3.tgz",
+			"integrity": "sha512-r+GLATzCjjQI82bgrIPXWEYBwZonSO64OThk5wU6HduZlDYTEDxZsFNoNoesCDWCgRrgg+OXj7WLNy1WlvfX7w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-linux-arm-gnueabihf": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.3.tgz",
+			"integrity": "sha512-juvRj1QX9jmQScL4nV0rROtYUFgWP76zfdn1fdfZ2BhvwUugIAq8x+jLVGlnXKUhDrP9+RrAufqXjjVkK+uBxA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-linux-arm64-gnu": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.3.tgz",
+			"integrity": "sha512-hzinybStPB+SzS68hR5rzOngOH7Yd/jFuWGeg9qS5WifYXHpqwGH2BQeKpjVV0iJuyO9r309JKrRWMrbfhnuBA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-linux-arm64-musl": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.3.tgz",
+			"integrity": "sha512-oyfQYljCwf+9zUu1YkTZbRbyxmcHzvJPMGOxC3kJOReh3kCUoGcmvAxUPMtFD6FSYjJ+eaog4+2IFHtYuAw/bQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-linux-x64-gnu": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.3.tgz",
+			"integrity": "sha512-epv4FMazj/XG70KTTnrZ0H1VtL6DeWOvyHLHYy7f5PdgDpBXpDTFjVqhP8NFNH8HmaDDdeL1NvQD07AXhyvUKA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-linux-x64-musl": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.3.tgz",
+			"integrity": "sha512-bG5QODFy59XnSFTiPyIAt+rbPdphtvQMibtOVvyjwIwsBUw7swJ6k+6PSPVYEYpi6SHzi3qYBsro39ayGJKQJg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-win32-arm64-msvc": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.3.tgz",
+			"integrity": "sha512-FbnT3reJ3MbTJ5W0hvlCCGGVDSpburzT5XGC9ljBJ4kr+85iNTLjv7+vrPeDdwHEqtGmdZgnabkLVCI4yFyCag==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-win32-ia32-msvc": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.3.tgz",
+			"integrity": "sha512-M/fKZC2tMGWA6eTsIniNEBpx2prdR8lIxvSO3gv5P6ymZOGVWCvEMksnTkPAjHnU6d8r8eCiuGKm3UNo7zCTpQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/@next/swc-win32-x64-msvc": {
+			"version": "12.3.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.3.tgz",
+			"integrity": "sha512-Ku9mfGwmNtk44o4B/jEWUxBAT4tJ3S7QbBMLJdL1GmtRZ05LGL36OqWjLvBPr8dFiHOQQbYoAmYfQw7zeGypYA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/next12/node_modules/styled-jsx": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
+			"integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -6266,18 +6198,6 @@
 				}
 			}
 		},
-		"node_modules/node-preload": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-			"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-			"dev": true,
-			"dependencies": {
-				"process-on-spawn": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
@@ -6306,207 +6226,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/nyc": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-			"dev": true,
-			"dependencies": {
-				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"caching-transform": "^4.0.0",
-				"convert-source-map": "^1.7.0",
-				"decamelize": "^1.2.0",
-				"find-cache-dir": "^3.2.0",
-				"find-up": "^4.1.0",
-				"foreground-child": "^2.0.0",
-				"get-package-type": "^0.1.0",
-				"glob": "^7.1.6",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-hook": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.0",
-				"istanbul-lib-processinfo": "^2.0.2",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"make-dir": "^3.0.0",
-				"node-preload": "^0.2.1",
-				"p-map": "^3.0.0",
-				"process-on-spawn": "^1.0.0",
-				"resolve-from": "^5.0.0",
-				"rimraf": "^3.0.0",
-				"signal-exit": "^3.0.2",
-				"spawn-wrap": "^2.0.0",
-				"test-exclude": "^6.0.0",
-				"yargs": "^15.0.2"
-			},
-			"bin": {
-				"nyc": "bin/nyc.js"
-			},
-			"engines": {
-				"node": ">=8.9"
-			}
-		},
-		"node_modules/nyc/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/nyc/node_modules/cliui": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^6.2.0"
-			}
-		},
-		"node_modules/nyc/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/nyc/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/nyc/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/nyc/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/y18n": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-			"dev": true
-		},
-		"node_modules/nyc/node_modules/yargs": {
-			"version": "15.4.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^6.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^4.1.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^4.2.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/yargs-parser": {
-			"version": "18.1.3",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/object-assign": {
@@ -6671,18 +6390,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-			"dev": true,
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6690,21 +6397,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/package-hash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.15",
-				"hasha": "^5.0.0",
-				"lodash.flattendeep": "^4.4.0",
-				"release-zalgo": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/param-case": {
@@ -6846,70 +6538,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pkg-dir/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/postcss": {
 			"version": "8.4.14",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -6992,18 +6620,6 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
-		},
-		"node_modules/process-on-spawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-			"integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
-			"dev": true,
-			"dependencies": {
-				"fromentries": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/promise": {
 			"version": "8.2.0",
@@ -7395,18 +7011,6 @@
 				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
-		"node_modules/release-zalgo": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-			"integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
-			"dev": true,
-			"dependencies": {
-				"es6-error": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7415,12 +7019,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "2.0.0-next.4",
@@ -7598,12 +7196,6 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7710,23 +7302,6 @@
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
-		"node_modules/spawn-wrap": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-			"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-			"dev": true,
-			"dependencies": {
-				"foreground-child": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"make-dir": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"signal-exit": "^3.0.2",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -7779,12 +7354,6 @@
 			"dependencies": {
 				"readable-stream": "^3.0.0"
 			}
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
 		},
 		"node_modules/standard-version": {
 			"version": "9.5.0",
@@ -7898,15 +7467,6 @@
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-bom": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -8242,29 +7802,11 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true
-		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dev": true,
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
-			}
 		},
 		"node_modules/typescript": {
 			"version": "4.8.4",
@@ -8396,15 +7938,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
-		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/uvu": {
 			"version": "0.5.6",
@@ -8676,12 +8209,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-			"dev": true
-		},
 		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -8752,18 +8279,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
-		},
-		"node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
-			}
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -9230,83 +8745,6 @@
 			"resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
 			"integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
 			"dev": true
-		},
-		"@istanbuljs/load-nyc-config": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.3.1",
-				"find-up": "^4.1.0",
-				"get-package-type": "^0.1.0",
-				"js-yaml": "^3.13.1",
-				"resolve-from": "^5.0.0"
-			},
-			"dependencies": {
-				"argparse": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-					"dev": true,
-					"requires": {
-						"sprintf-js": "~1.0.2"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				}
-			}
 		},
 		"@istanbuljs/schema": {
 			"version": "0.1.3",
@@ -9906,16 +9344,6 @@
 			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
 			"dev": true
 		},
-		"aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dev": true,
-			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			}
-		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -9952,21 +9380,6 @@
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
 			}
-		},
-		"append-transform": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-			"dev": true,
-			"requires": {
-				"default-require-extensions": "^3.0.0"
-			}
-		},
-		"archy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
-			"dev": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -10114,18 +9527,6 @@
 				"v8-to-istanbul": "^9.0.0",
 				"yargs": "^16.2.0",
 				"yargs-parser": "^20.2.9"
-			}
-		},
-		"caching-transform": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-			"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
-			"dev": true,
-			"requires": {
-				"hasha": "^5.0.0",
-				"make-dir": "^3.0.0",
-				"package-hash": "^4.0.0",
-				"write-file-atomic": "^3.0.0"
 			}
 		},
 		"call-bind": {
@@ -10285,12 +9686,6 @@
 			"integrity": "sha512-CLOGsVDrVamzv8sXJGaILUVI6dsuAkouJP/n6t+OxLPeeA4DDby7zn9SB6EUpa1H7oIKoE+rMmkW80zYsFfUjA==",
 			"dev": true
 		},
-		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true
-		},
 		"client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -10336,12 +9731,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
 			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-			"dev": true
-		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
 			"dev": true
 		},
 		"compare-func": {
@@ -10690,15 +10079,6 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
-		"default-require-extensions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
-			"integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
-			"dev": true,
-			"requires": {
-				"strip-bom": "^4.0.0"
-			}
-		},
 		"define-properties": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -10909,12 +10289,6 @@
 				"is-date-object": "^1.0.1",
 				"is-symbol": "^1.0.2"
 			}
-		},
-		"es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
 		},
 		"esbuild": {
 			"version": "0.15.10",
@@ -11355,12 +10729,6 @@
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
 		"esquery": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -11481,17 +10849,6 @@
 				"to-regex-range": "^5.0.1"
 			}
 		},
-		"find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-			"dev": true,
-			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
-			}
-		},
 		"find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -11538,12 +10895,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"fromentries": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-			"dev": true
 		},
 		"fs-extra": {
 			"version": "10.1.0",
@@ -11621,12 +10972,6 @@
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.3"
 			}
-		},
-		"get-package-type": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-			"dev": true
 		},
 		"get-pkg-repo": {
 			"version": "4.2.1",
@@ -11880,16 +11225,6 @@
 			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
-			}
-		},
-		"hasha": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-			"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-			"dev": true,
-			"requires": {
-				"is-stream": "^2.0.0",
-				"type-fest": "^0.8.0"
 			}
 		},
 		"he": {
@@ -12194,12 +11529,6 @@
 				"call-bind": "^1.0.2"
 			}
 		},
-		"is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true
-		},
 		"is-string": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -12227,12 +11556,6 @@
 				"text-extensions": "^1.0.0"
 			}
 		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-			"dev": true
-		},
 		"is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -12241,12 +11564,6 @@
 			"requires": {
 				"call-bind": "^1.0.2"
 			}
-		},
-		"is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -12265,49 +11582,6 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
 			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
 			"dev": true
-		},
-		"istanbul-lib-hook": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-			"dev": true,
-			"requires": {
-				"append-transform": "^2.0.0"
-			}
-		},
-		"istanbul-lib-instrument": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.7.5",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.0.0",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
-		"istanbul-lib-processinfo": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
-			"integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
-			"dev": true,
-			"requires": {
-				"archy": "^1.0.0",
-				"cross-spawn": "^7.0.3",
-				"istanbul-lib-coverage": "^3.2.0",
-				"p-map": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"uuid": "^8.3.2"
-			}
 		},
 		"istanbul-lib-report": {
 			"version": "3.0.0",
@@ -12335,17 +11609,6 @@
 						"has-flag": "^4.0.0"
 					}
 				}
-			}
-		},
-		"istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
 			}
 		},
 		"istanbul-reports": {
@@ -12542,12 +11805,6 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
 			"dev": true
 		},
 		"lodash.ismatch": {
@@ -13180,6 +12437,139 @@
 				"use-sync-external-store": "1.2.0"
 			}
 		},
+		"next12": {
+			"version": "npm:next@12.3.3",
+			"resolved": "https://registry.npmjs.org/next/-/next-12.3.3.tgz",
+			"integrity": "sha512-Rx2Y6Wl5R8E77NOfBupp/B9OPCklqfqD0yN2+rDivhMjd6hjVFH5n0WTDI4PWwDmZsdNcYt6NV85kJ3PLR+eNQ==",
+			"dev": true,
+			"requires": {
+				"@next/env": "12.3.3",
+				"@next/swc-android-arm-eabi": "12.3.3",
+				"@next/swc-android-arm64": "12.3.3",
+				"@next/swc-darwin-arm64": "12.3.3",
+				"@next/swc-darwin-x64": "12.3.3",
+				"@next/swc-freebsd-x64": "12.3.3",
+				"@next/swc-linux-arm-gnueabihf": "12.3.3",
+				"@next/swc-linux-arm64-gnu": "12.3.3",
+				"@next/swc-linux-arm64-musl": "12.3.3",
+				"@next/swc-linux-x64-gnu": "12.3.3",
+				"@next/swc-linux-x64-musl": "12.3.3",
+				"@next/swc-win32-arm64-msvc": "12.3.3",
+				"@next/swc-win32-ia32-msvc": "12.3.3",
+				"@next/swc-win32-x64-msvc": "12.3.3",
+				"@swc/helpers": "0.4.11",
+				"caniuse-lite": "^1.0.30001406",
+				"postcss": "8.4.14",
+				"styled-jsx": "5.0.7",
+				"use-sync-external-store": "1.2.0"
+			},
+			"dependencies": {
+				"@next/env": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.3.tgz",
+					"integrity": "sha512-H2pKuOasV9RgvVaWosB2rGSNeQShQpiDaF4EEjLyagIc3HwqdOw2/VAG/8Lq+adOwPv2P73O1hulTNad3k5MDw==",
+					"dev": true
+				},
+				"@next/swc-android-arm-eabi": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.3.tgz",
+					"integrity": "sha512-5O/ZIX6hlIRGMy1R2f/8WiCZ4Hp4WTC0FcTuz8ycQ28j/mzDnmzjVoayVVr+ZmfEKQayFrRu+vxHjFyY0JGQlQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-android-arm64": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.3.tgz",
+					"integrity": "sha512-2QWreRmlxYRDtnLYn+BI8oukHwcP7W0zGIY5R2mEXRjI4ARqCLdu8RmcT9Vemw7RfeAVKA/4cv/9PY0pCcQpNA==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-darwin-arm64": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.3.tgz",
+					"integrity": "sha512-GtZdDLerM+VToCMFp+W+WhnT6sxHePQH4xZZiYD/Y8KFiwHbDRcJr2FPG0bAJnGNiSvv/QQnBq74wjZ9+7vhcQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-darwin-x64": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.3.tgz",
+					"integrity": "sha512-gRYvTKrRYynjFQUDJ+upHMcBiNz0ii0m7zGgmUTlTSmrBWqVSzx79EHYT7Nn4GWHM+a/W+2VXfu+lqHcJeQ9gQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-freebsd-x64": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.3.tgz",
+					"integrity": "sha512-r+GLATzCjjQI82bgrIPXWEYBwZonSO64OThk5wU6HduZlDYTEDxZsFNoNoesCDWCgRrgg+OXj7WLNy1WlvfX7w==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-linux-arm-gnueabihf": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.3.tgz",
+					"integrity": "sha512-juvRj1QX9jmQScL4nV0rROtYUFgWP76zfdn1fdfZ2BhvwUugIAq8x+jLVGlnXKUhDrP9+RrAufqXjjVkK+uBxA==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-linux-arm64-gnu": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.3.tgz",
+					"integrity": "sha512-hzinybStPB+SzS68hR5rzOngOH7Yd/jFuWGeg9qS5WifYXHpqwGH2BQeKpjVV0iJuyO9r309JKrRWMrbfhnuBA==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-linux-arm64-musl": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.3.tgz",
+					"integrity": "sha512-oyfQYljCwf+9zUu1YkTZbRbyxmcHzvJPMGOxC3kJOReh3kCUoGcmvAxUPMtFD6FSYjJ+eaog4+2IFHtYuAw/bQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-linux-x64-gnu": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.3.tgz",
+					"integrity": "sha512-epv4FMazj/XG70KTTnrZ0H1VtL6DeWOvyHLHYy7f5PdgDpBXpDTFjVqhP8NFNH8HmaDDdeL1NvQD07AXhyvUKA==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-linux-x64-musl": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.3.tgz",
+					"integrity": "sha512-bG5QODFy59XnSFTiPyIAt+rbPdphtvQMibtOVvyjwIwsBUw7swJ6k+6PSPVYEYpi6SHzi3qYBsro39ayGJKQJg==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-win32-arm64-msvc": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.3.tgz",
+					"integrity": "sha512-FbnT3reJ3MbTJ5W0hvlCCGGVDSpburzT5XGC9ljBJ4kr+85iNTLjv7+vrPeDdwHEqtGmdZgnabkLVCI4yFyCag==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-win32-ia32-msvc": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.3.tgz",
+					"integrity": "sha512-M/fKZC2tMGWA6eTsIniNEBpx2prdR8lIxvSO3gv5P6ymZOGVWCvEMksnTkPAjHnU6d8r8eCiuGKm3UNo7zCTpQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@next/swc-win32-x64-msvc": {
+					"version": "12.3.3",
+					"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.3.tgz",
+					"integrity": "sha512-Ku9mfGwmNtk44o4B/jEWUxBAT4tJ3S7QbBMLJdL1GmtRZ05LGL36OqWjLvBPr8dFiHOQQbYoAmYfQw7zeGypYA==",
+					"dev": true,
+					"optional": true
+				},
+				"styled-jsx": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
+					"integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
+					"dev": true,
+					"requires": {}
+				}
+			}
+		},
 		"no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -13197,15 +12587,6 @@
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
-			}
-		},
-		"node-preload": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-			"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-			"dev": true,
-			"requires": {
-				"process-on-spawn": "^1.0.0"
 			}
 		},
 		"node-releases": {
@@ -13231,167 +12612,6 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
-		},
-		"nyc": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-			"dev": true,
-			"requires": {
-				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"caching-transform": "^4.0.0",
-				"convert-source-map": "^1.7.0",
-				"decamelize": "^1.2.0",
-				"find-cache-dir": "^3.2.0",
-				"find-up": "^4.1.0",
-				"foreground-child": "^2.0.0",
-				"get-package-type": "^0.1.0",
-				"glob": "^7.1.6",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-hook": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.0",
-				"istanbul-lib-processinfo": "^2.0.2",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.2",
-				"make-dir": "^3.0.0",
-				"node-preload": "^0.2.1",
-				"p-map": "^3.0.0",
-				"process-on-spawn": "^1.0.0",
-				"resolve-from": "^5.0.0",
-				"rimraf": "^3.0.0",
-				"signal-exit": "^3.0.2",
-				"spawn-wrap": "^2.0.0",
-				"test-exclude": "^6.0.0",
-				"yargs": "^15.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"resolve-from": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"y18n": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"dev": true,
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -13507,32 +12727,11 @@
 				"p-limit": "^3.0.2"
 			}
 		},
-		"p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-			"dev": true,
-			"requires": {
-				"aggregate-error": "^3.0.0"
-			}
-		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
-		},
-		"package-hash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.15",
-				"hasha": "^5.0.0",
-				"lodash.flattendeep": "^4.4.0",
-				"release-zalgo": "^1.0.0"
-			}
 		},
 		"param-case": {
 			"version": "3.0.4",
@@ -13643,54 +12842,6 @@
 			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
 			"dev": true
 		},
-		"pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"requires": {
-				"find-up": "^4.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				}
-			}
-		},
 		"postcss": {
 			"version": "8.4.14",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -13739,15 +12890,6 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
-		},
-		"process-on-spawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-			"integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
-			"dev": true,
-			"requires": {
-				"fromentries": "^1.2.0"
-			}
 		},
 		"promise": {
 			"version": "8.2.0",
@@ -14040,25 +13182,10 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
-		"release-zalgo": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-			"integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
-			"dev": true,
-			"requires": {
-				"es6-error": "^4.0.1"
-			}
-		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
 		"resolve": {
@@ -14172,12 +13299,6 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14260,20 +13381,6 @@
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
-		"spawn-wrap": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-			"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-			"dev": true,
-			"requires": {
-				"foreground-child": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"make-dir": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"signal-exit": "^3.0.2",
-				"which": "^2.0.1"
-			}
-		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -14323,12 +13430,6 @@
 			"requires": {
 				"readable-stream": "^3.0.0"
 			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
 		},
 		"standard-version": {
 			"version": "9.5.0",
@@ -14424,12 +13525,6 @@
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
-		},
-		"strip-bom": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-			"dev": true
 		},
 		"strip-indent": {
 			"version": "3.0.0",
@@ -14689,26 +13784,11 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
-		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true
-		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true
-		},
-		"typedarray-to-buffer": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dev": true,
-			"requires": {
-				"is-typedarray": "^1.0.0"
-			}
 		},
 		"typescript": {
 			"version": "4.8.4",
@@ -14798,12 +13878,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"dev": true
 		},
 		"uvu": {
@@ -14967,12 +14041,6 @@
 				"is-symbol": "^1.0.3"
 			}
 		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-			"dev": true
-		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -15027,18 +14095,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
-		},
-		"write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"requires": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
-			}
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"prettier": "^2.7.1",
 		"prettier-plugin-jsdoc": "^0.4.2",
 		"react": "^18.1.0",
+		"react-dom": "^18.2.0",
 		"react-test-renderer": "^18.2.0",
 		"size-limit": "^8.1.0",
 		"standard-version": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
 		"eslint-plugin-tsdoc": "^0.2.17",
 		"happy-dom": "^7.5.13",
 		"next": "^13.0.0",
-		"nyc": "^15.1.0",
 		"prettier": "^2.7.1",
 		"prettier-plugin-jsdoc": "^0.4.2",
 		"react": "^18.1.0",
@@ -81,8 +80,8 @@
 	},
 	"peerDependencies": {
 		"@prismicio/client": "^6",
-		"next": "^11 || ^12 || ^13",
-		"react": "^17 || ^18"
+		"next": "^13",
+		"react": "^18"
 	},
 	"engines": {
 		"node": ">=14.15.0"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 	},
 	"peerDependencies": {
 		"@prismicio/client": "^6.0.0",
-		"next": "^11 || ^12 | ^13",
+		"next": "^11 || ^12 || ^13",
 		"react": "^17 || ^18"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-tsdoc": "^0.2.17",
 		"happy-dom": "^7.5.13",
-		"next": "^12.1.4",
+		"next": "^13.0.0",
 		"nyc": "^15.1.0",
 		"prettier": "^2.7.1",
 		"prettier-plugin-jsdoc": "^0.4.2",
@@ -81,7 +81,7 @@
 	},
 	"peerDependencies": {
 		"@prismicio/client": "^6.0.0",
-		"next": "^11 || ^12",
+		"next": "^11 || ^12 | ^13",
 		"react": "^17 || ^18"
 	},
 	"engines": {

--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -105,7 +105,7 @@ export const PrismicNextImage = ({
 	height,
 	fallback = null,
 	...restProps
-}: PrismicNextImageProps): React.ReactNode => {
+}: PrismicNextImageProps): JSX.Element => {
 	if (!__PRODUCTION__) {
 		if (typeof alt === "string" && alt !== "") {
 			console.warn(
@@ -157,6 +157,6 @@ export const PrismicNextImage = ({
 			/>
 		);
 	} else {
-		return fallback;
+		return <>{fallback}</>;
 	}
 };

--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -101,6 +101,7 @@ export const PrismicNextImage = ({
 	imgixParams = {},
 	alt,
 	fallbackAlt,
+	fill,
 	...restProps
 }: PrismicNextImageProps) => {
 	if (!__PRODUCTION__) {
@@ -156,8 +157,8 @@ export const PrismicNextImage = ({
 		return (
 			<Image
 				src={src}
-				width={layout === "fill" ? undefined : resolvedWidth}
-				height={layout === "fill" ? undefined : resolvedHeight}
+				width={fill || layout === "fill" ? undefined : resolvedWidth}
+				height={fill || layout === "fill" ? undefined : resolvedHeight}
 				// A non-null assertion is required since we
 				// can't statically know if an alt attribute is
 				// available.

--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -1,10 +1,12 @@
-import Image, { ImageProps, ImageLoaderProps } from "next/image";
+import Image, { ImageProps } from "next/image";
 import { buildURL, ImgixURLParams } from "imgix-url-builder";
 import * as prismicH from "@prismicio/helpers";
 import * as prismicT from "@prismicio/types";
 
 import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
 import { devMsg } from "./lib/devMsg";
+
+import { imgixLoader } from "./imgixLoader";
 
 const castInt = (input: string | number | undefined): number | undefined => {
 	if (typeof input === "number" || typeof input === "undefined") {
@@ -18,29 +20,6 @@ const castInt = (input: string | number | undefined): number | undefined => {
 			return parsed;
 		}
 	}
-};
-
-/**
- * A `next/image` loader for Imgix, which Prismic uses, with an optional
- * collection of default Imgix parameters.
- *
- * @see To learn about `next/image` loaders: https://nextjs.org/docs/api-reference/next/image#loader
- * @see To learn about Imgix's URL API: https://docs.imgix.com/apis/rendering
- */
-export const imgixLoader = (args: ImageLoaderProps): string => {
-	const url = new URL(args.src);
-
-	const params: ImgixURLParams = {
-		fit: (url.searchParams.get("fit") as ImgixURLParams["fit"]) || "max",
-		w: args.width,
-		h: undefined,
-	};
-
-	if (args.quality) {
-		params.q = args.quality;
-	}
-
-	return buildURL(args.src, params);
 };
 
 export type PrismicNextImageProps = Omit<ImageProps, "src" | "alt"> & {

--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -21,13 +21,13 @@ const castInt = (input: string | number | undefined): number | undefined => {
 };
 
 /**
- * Creates a `next/image` loader for Imgix, which Prismic uses, with an optional
+ * A `next/image` loader for Imgix, which Prismic uses, with an optional
  * collection of default Imgix parameters.
  *
  * @see To learn about `next/image` loaders: https://nextjs.org/docs/api-reference/next/image#loader
  * @see To learn about Imgix's URL API: https://docs.imgix.com/apis/rendering
  */
-const imgixLoader = (args: ImageLoaderProps): string => {
+export const imgixLoader = (args: ImageLoaderProps): string => {
 	const url = new URL(args.src);
 
 	const params: ImgixURLParams = {

--- a/src/PrismicPreview.tsx
+++ b/src/PrismicPreview.tsx
@@ -54,7 +54,7 @@ export function PrismicPreview({
 	children,
 	updatePreviewURL = "/api/preview",
 	exitPreviewURL = "/api/exit-preview",
-}: PrismicPreviewProps): JSX.Element {
+}: PrismicPreviewProps): React.ReactNode {
 	const router = useRouter();
 
 	const resolvedUpdatePreviewURL = router.basePath + updatePreviewURL;

--- a/src/imgixLoader.ts
+++ b/src/imgixLoader.ts
@@ -1,0 +1,25 @@
+import { ImageLoaderProps } from "next/image";
+import { buildURL, ImgixURLParams } from "imgix-url-builder";
+
+/**
+ * A `next/image` loader for Imgix, which Prismic uses, with an optional
+ * collection of default Imgix parameters.
+ *
+ * @see To learn about `next/image` loaders: https://nextjs.org/docs/api-reference/next/image#loader
+ * @see To learn about Imgix's URL API: https://docs.imgix.com/apis/rendering
+ */
+export const imgixLoader = (args: ImageLoaderProps): string => {
+	const url = new URL(args.src);
+
+	const params: ImgixURLParams = {
+		fit: (url.searchParams.get("fit") as ImgixURLParams["fit"]) || "max",
+		w: args.width,
+		h: undefined,
+	};
+
+	if (args.quality) {
+		params.q = args.quality;
+	}
+
+	return buildURL(args.src, params);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,23 @@
-export { setPreviewData } from "./setPreviewData";
-export type { SetPreviewDataConfig } from "./setPreviewData";
+export { setPreviewData, SetPreviewDataConfig } from "./setPreviewData";
 
-export { exitPreview } from "./exitPreview";
-export type { ExitPreviewConfig } from "./exitPreview";
+export { exitPreview, ExitPreviewConfig } from "./exitPreview";
 
-export { PrismicPreview } from "./PrismicPreview";
-export type { PrismicPreviewProps } from "./PrismicPreview";
+export { PrismicPreview, PrismicPreviewProps } from "./PrismicPreview";
 
-export { enableAutoPreviews } from "./enableAutoPreviews";
-export type { EnableAutoPreviewsConfig } from "./enableAutoPreviews";
+export {
+	EnableAutoPreviewsConfig,
+	enableAutoPreviews,
+} from "./enableAutoPreviews";
 
-export { redirectToPreviewURL } from "./redirectToPreviewURL";
-export type { RedirectToPreviewURLConfig } from "./redirectToPreviewURL";
+export {
+	RedirectToPreviewURLConfig,
+	redirectToPreviewURL,
+} from "./redirectToPreviewURL";
 
-export { PrismicNextImage } from "./PrismicNextImage";
-export type { PrismicNextImageProps } from "./PrismicNextImage";
+export {
+	PrismicNextImage,
+	PrismicNextImageProps,
+	imgixLoader,
+} from "./PrismicNextImage";
 
-export type { CreateClientConfig } from "./types";
+export { CreateClientConfig } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,8 @@ export {
 	redirectToPreviewURL,
 } from "./redirectToPreviewURL";
 
-export {
-	PrismicNextImage,
-	PrismicNextImageProps,
-	imgixLoader,
-} from "./PrismicNextImage";
+export { PrismicNextImage, PrismicNextImageProps } from "./PrismicNextImage";
+
+export { imgixLoader } from "./imgixLoader";
 
 export { CreateClientConfig } from "./types";

--- a/test/PrismicNextImage.test.tsx
+++ b/test/PrismicNextImage.test.tsx
@@ -1,4 +1,5 @@
-import { test, expect, vi, describe } from "vitest";
+import { test, expect, vi } from "vitest";
+// import { test, expect, vi, describe } from "vitest";
 import * as React from "react";
 import * as renderer from "react-test-renderer";
 
@@ -62,63 +63,63 @@ test("renders a NextImage for a given field", (ctx) => {
 	);
 });
 
-test('supports layout="responsive"', (ctx) => {
-	const field = ctx.mock.value.image();
-
-	const res = renderJSON(
-		<PrismicNextImage field={field} layout="responsive" />,
-	);
-	const img = getImg(res);
-
-	expect(img?.props.src).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=3840&fit=crop"',
-	);
-	expect(img?.props.srcSet).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 640w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=750&fit=crop 750w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=828&fit=crop 828w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=3840&fit=crop 3840w"',
-	);
-});
-
-test('supports layout="fill"', (ctx) => {
-	const field = ctx.mock.value.image();
-
-	const res = renderJSON(<PrismicNextImage field={field} layout="fill" />);
-	const img = getImg(res);
-
-	expect(img?.props.src).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop"',
-	);
-	expect(img?.props.srcSet).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=640&fit=crop 640w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=750&fit=crop 750w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=828&fit=crop 828w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop 3840w"',
-	);
-});
-
-test('supports layout="fixed"', (ctx) => {
-	const field = ctx.mock.value.image();
-
-	const res = renderJSON(<PrismicNextImage field={field} layout="fixed" />);
-	const img = getImg(res);
-
-	expect(img?.props.src).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop"',
-	);
-	expect(img?.props.srcSet).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop 1x"',
-	);
-});
-
-test('supports layout="intrinsic"', (ctx) => {
-	const field = ctx.mock.value.image();
-
-	const res = renderJSON(<PrismicNextImage field={field} layout="intrinsic" />);
-	const img = getImg(res);
-
-	expect(img?.props.src).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop"',
-	);
-	expect(img?.props.srcSet).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop 1x"',
-	);
-});
+// test('supports layout="responsive"', (ctx) => {
+// 	const field = ctx.mock.value.image();
+//
+// 	const res = renderJSON(
+// 		<PrismicNextImage field={field} layout="responsive" />,
+// 	);
+// 	const img = getImg(res);
+//
+// 	expect(img?.props.src).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=3840&fit=crop"',
+// 	);
+// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 640w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=750&fit=crop 750w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=828&fit=crop 828w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=3840&fit=crop 3840w"',
+// 	);
+// });
+//
+// test('supports layout="fill"', (ctx) => {
+// 	const field = ctx.mock.value.image();
+//
+// 	const res = renderJSON(<PrismicNextImage field={field} layout="fill" />);
+// 	const img = getImg(res);
+//
+// 	expect(img?.props.src).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop"',
+// 	);
+// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=640&fit=crop 640w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=750&fit=crop 750w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=828&fit=crop 828w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop 3840w"',
+// 	);
+// });
+//
+// test('supports layout="fixed"', (ctx) => {
+// 	const field = ctx.mock.value.image();
+//
+// 	const res = renderJSON(<PrismicNextImage field={field} layout="fixed" />);
+// 	const img = getImg(res);
+//
+// 	expect(img?.props.src).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop"',
+// 	);
+// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop 1x"',
+// 	);
+// });
+//
+// test('supports layout="intrinsic"', (ctx) => {
+// 	const field = ctx.mock.value.image();
+//
+// 	const res = renderJSON(<PrismicNextImage field={field} layout="intrinsic" />);
+// 	const img = getImg(res);
+//
+// 	expect(img?.props.src).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop"',
+// 	);
+// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop 1x"',
+// 	);
+// });
 
 test("uses the field's alt if given", (ctx) => {
 	const field = ctx.mock.value.image();
@@ -289,145 +290,145 @@ test("supports imgix parameters when using the default loader", (ctx) => {
 	expect(nextImageOptimizationAPIURL.searchParams.get("sat")).toBe("-100");
 });
 
-describe("intrinsic layout (default)", () => {
-	test("supports automatic dimensiosn", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const res = renderJSON(<PrismicNextImage field={field} />);
-		const img = getImg(res);
-
-		expect(img?.props.src).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop"',
-		);
-		expect(img?.props.srcSet).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=828&fit=crop 1x, https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop 2x"',
-		);
-	});
-
-	test("supports explicit width", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const res = renderJSON(<PrismicNextImage field={field} width="400" />);
-		const img = getImg(res);
-
-		expect(img?.props.src).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop"',
-		);
-		expect(img?.props.srcSet).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=640&fit=crop 1x, https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop 2x"',
-		);
-	});
-
-	test("supports explicit height", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const res = renderJSON(<PrismicNextImage field={field} height="400" />);
-		const img = getImg(res);
-
-		expect(img?.props.src).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop"',
-		);
-		expect(img?.props.srcSet).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 1x, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 2x"',
-		);
-	});
-
-	test("throws if invalid width or height is given", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const consoleErrorSpy = vi
-			.spyOn(console, "error")
-			.mockImplementation(() => void 0);
-
-		expect(() => {
-			renderJSON(<PrismicNextImage field={field} width="NaN" height="NaN" />);
-		}).toThrow('invalid "width" or "height" property');
-
-		consoleErrorSpy.mockRestore();
-	});
-});
-
-describe("fixed layout", () => {
-	test("supports automatic dimensiosn", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const res = renderJSON(<PrismicNextImage field={field} layout="fixed" />);
-		const img = getImg(res);
-
-		expect(img?.props.src).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop"',
-		);
-		expect(img?.props.srcSet).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=828&fit=crop 1x, https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop 2x"',
-		);
-	});
-
-	test("supports explicit width", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const res = renderJSON(
-			<PrismicNextImage field={field} width="400" layout="fixed" />,
-		);
-		const img = getImg(res);
-
-		expect(img?.props.src).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop"',
-		);
-		expect(img?.props.srcSet).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=640&fit=crop 1x, https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop 2x"',
-		);
-	});
-
-	test("supports explicit height", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const res = renderJSON(
-			<PrismicNextImage field={field} height="400" layout="fixed" />,
-		);
-		const img = getImg(res);
-
-		expect(img?.props.src).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop"',
-		);
-		expect(img?.props.srcSet).toMatchInlineSnapshot(
-			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 1x, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 2x"',
-		);
-	});
-
-	test("throws if invalid width or height is given", (ctx) => {
-		const field = ctx.mock.value.image();
-		field.dimensions.width = 800;
-		field.dimensions.height = 600;
-
-		const consoleErrorSpy = vi
-			.spyOn(console, "error")
-			.mockImplementation(() => void 0);
-
-		expect(() => {
-			renderJSON(
-				<PrismicNextImage
-					field={field}
-					width="NaN"
-					height="NaN"
-					layout="fixed"
-				/>,
-			);
-		}).toThrow('invalid "width" or "height" property');
-
-		consoleErrorSpy.mockRestore();
-	});
-});
+// describe("intrinsic layout (default)", () => {
+// 	test("supports automatic dimensiosn", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const res = renderJSON(<PrismicNextImage field={field} />);
+// 		const img = getImg(res);
+//
+// 		expect(img?.props.src).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop"',
+// 		);
+// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=828&fit=crop 1x, https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop 2x"',
+// 		);
+// 	});
+//
+// 	test("supports explicit width", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const res = renderJSON(<PrismicNextImage field={field} width="400" />);
+// 		const img = getImg(res);
+//
+// 		expect(img?.props.src).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop"',
+// 		);
+// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=640&fit=crop 1x, https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop 2x"',
+// 		);
+// 	});
+//
+// 	test("supports explicit height", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const res = renderJSON(<PrismicNextImage field={field} height="400" />);
+// 		const img = getImg(res);
+//
+// 		expect(img?.props.src).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop"',
+// 		);
+// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 1x, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 2x"',
+// 		);
+// 	});
+//
+// 	test("throws if invalid width or height is given", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const consoleErrorSpy = vi
+// 			.spyOn(console, "error")
+// 			.mockImplementation(() => void 0);
+//
+// 		expect(() => {
+// 			renderJSON(<PrismicNextImage field={field} width="NaN" height="NaN" />);
+// 		}).toThrow('invalid "width" or "height" property');
+//
+// 		consoleErrorSpy.mockRestore();
+// 	});
+// });
+//
+// describe("fixed layout", () => {
+// 	test("supports automatic dimensiosn", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const res = renderJSON(<PrismicNextImage field={field} layout="fixed" />);
+// 		const img = getImg(res);
+//
+// 		expect(img?.props.src).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop"',
+// 		);
+// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=828&fit=crop 1x, https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop 2x"',
+// 		);
+// 	});
+//
+// 	test("supports explicit width", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const res = renderJSON(
+// 			<PrismicNextImage field={field} width="400" layout="fixed" />,
+// 		);
+// 		const img = getImg(res);
+//
+// 		expect(img?.props.src).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop"',
+// 		);
+// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=640&fit=crop 1x, https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop 2x"',
+// 		);
+// 	});
+//
+// 	test("supports explicit height", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const res = renderJSON(
+// 			<PrismicNextImage field={field} height="400" layout="fixed" />,
+// 		);
+// 		const img = getImg(res);
+//
+// 		expect(img?.props.src).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop"',
+// 		);
+// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
+// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 1x, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 2x"',
+// 		);
+// 	});
+//
+// 	test("throws if invalid width or height is given", (ctx) => {
+// 		const field = ctx.mock.value.image();
+// 		field.dimensions.width = 800;
+// 		field.dimensions.height = 600;
+//
+// 		const consoleErrorSpy = vi
+// 			.spyOn(console, "error")
+// 			.mockImplementation(() => void 0);
+//
+// 		expect(() => {
+// 			renderJSON(
+// 				<PrismicNextImage
+// 					field={field}
+// 					width="NaN"
+// 					height="NaN"
+// 					layout="fixed"
+// 				/>,
+// 			);
+// 		}).toThrow('invalid "width" or "height" property');
+//
+// 		consoleErrorSpy.mockRestore();
+// 	});
+// });

--- a/test/PrismicNextImage.test.tsx
+++ b/test/PrismicNextImage.test.tsx
@@ -4,14 +4,6 @@ import { renderJSON } from "./__testutils__/renderJSON";
 
 import { PrismicNextImage } from "../src";
 
-test("renders null when passed an empty field", (ctx) => {
-	const field = ctx.mock.value.image({ state: "empty" });
-
-	const img = renderJSON(<PrismicNextImage field={field} />);
-
-	expect(img).toBe(null);
-});
-
 test("renders a NextImage for a given field", (ctx) => {
 	const field = ctx.mock.value.image();
 
@@ -23,6 +15,26 @@ test("renders a NextImage for a given field", (ctx) => {
 	expect(img?.props.srcSet).toMatchInlineSnapshot(
 		'"https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=3840&fit=crop 1x"',
 	);
+});
+
+test("renders null when passed an empty field", (ctx) => {
+	const field = ctx.mock.value.image({ state: "empty" });
+
+	const img = renderJSON(<PrismicNextImage field={field} />);
+
+	expect(img).toBe(null);
+});
+
+test("renders fallback when passed an empty field", (ctx) => {
+	const field = ctx.mock.value.image({ state: "empty" });
+	const fallback = <div>custom fallback</div>;
+
+	const img = renderJSON(
+		<PrismicNextImage field={field} fallback={fallback} />,
+	);
+	const expected = renderJSON(fallback);
+
+	expect(img).toStrictEqual(expected);
 });
 
 test("supports an explicit width", (ctx) => {
@@ -66,7 +78,7 @@ test("supports an explicit width and height", (ctx) => {
 	);
 });
 
-test.only("handles a non-SafeNumber width and height", (ctx) => {
+test("handles a non-SafeNumber width and height", (ctx) => {
 	const field = ctx.mock.value.image();
 
 	const widthImg = renderJSON(

--- a/test/PrismicNextImage.test.tsx
+++ b/test/PrismicNextImage.test.tsx
@@ -1,59 +1,21 @@
 import { test, expect, vi } from "vitest";
-// import { test, expect, vi, describe } from "vitest";
-import * as React from "react";
-import * as renderer from "react-test-renderer";
+
+import { renderJSON } from "./__testutils__/renderJSON";
 
 import { PrismicNextImage } from "../src";
-
-/**
- * Renders a JSON representation of a React.Element. This is a helper to reduce
- * boilerplate in each test.
- *
- * @param element - The React.Element to render.
- *
- * @returns The JSON representation of `element`.
- */
-export const renderJSON = (
-	element: React.ReactElement,
-	options?: renderer.TestRendererOptions,
-): renderer.ReactTestRendererJSON | null => {
-	let root: renderer.ReactTestRenderer;
-
-	renderer.act(() => {
-		root = renderer.create(element, options);
-	});
-
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return root!.toJSON() as renderer.ReactTestRendererJSON;
-};
-
-const getImg = (
-	rendererJSON: renderer.ReactTestRendererJSON | null,
-): renderer.ReactTestRendererJSON | undefined => {
-	const noscript = rendererJSON?.children?.find(
-		(child) => (child as renderer.ReactTestRendererJSON).type === "noscript",
-	) as renderer.ReactTestRendererJSON;
-
-	if (noscript.children) {
-		return noscript.children.find(
-			(child) => (child as renderer.ReactTestRendererJSON).type === "img",
-		) as renderer.ReactTestRendererJSON;
-	}
-};
 
 test("renders null when passed an empty field", (ctx) => {
 	const field = ctx.mock.value.image({ state: "empty" });
 
-	const res = renderJSON(<PrismicNextImage field={field} />);
+	const img = renderJSON(<PrismicNextImage field={field} />);
 
-	expect(res).toBe(null);
+	expect(img).toBe(null);
 });
 
 test("renders a NextImage for a given field", (ctx) => {
 	const field = ctx.mock.value.image();
 
-	const res = renderJSON(<PrismicNextImage field={field} />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} />);
 
 	expect(img?.props.src).toMatchInlineSnapshot(
 		'"https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=3840&fit=crop"',
@@ -63,70 +25,108 @@ test("renders a NextImage for a given field", (ctx) => {
 	);
 });
 
-// test('supports layout="responsive"', (ctx) => {
-// 	const field = ctx.mock.value.image();
-//
-// 	const res = renderJSON(
-// 		<PrismicNextImage field={field} layout="responsive" />,
-// 	);
-// 	const img = getImg(res);
-//
-// 	expect(img?.props.src).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=3840&fit=crop"',
-// 	);
-// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 640w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=750&fit=crop 750w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=828&fit=crop 828w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=3840&fit=crop 3840w"',
-// 	);
-// });
-//
-// test('supports layout="fill"', (ctx) => {
-// 	const field = ctx.mock.value.image();
-//
-// 	const res = renderJSON(<PrismicNextImage field={field} layout="fill" />);
-// 	const img = getImg(res);
-//
-// 	expect(img?.props.src).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop"',
-// 	);
-// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=640&fit=crop 640w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=750&fit=crop 750w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=828&fit=crop 828w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop 3840w"',
-// 	);
-// });
-//
-// test('supports layout="fixed"', (ctx) => {
-// 	const field = ctx.mock.value.image();
-//
-// 	const res = renderJSON(<PrismicNextImage field={field} layout="fixed" />);
-// 	const img = getImg(res);
-//
-// 	expect(img?.props.src).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop"',
-// 	);
-// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1587502537745-84b86da1204f?w=3840&fit=crop 1x"',
-// 	);
-// });
-//
-// test('supports layout="intrinsic"', (ctx) => {
-// 	const field = ctx.mock.value.image();
-//
-// 	const res = renderJSON(<PrismicNextImage field={field} layout="intrinsic" />);
-// 	const img = getImg(res);
-//
-// 	expect(img?.props.src).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop"',
-// 	);
-// 	expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop 1x"',
-// 	);
-// });
+test("supports an explicit width", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const img = renderJSON(<PrismicNextImage field={field} width="400" />);
+
+	expect(img?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=828&fit=crop"',
+	);
+	expect(img?.props.srcSet).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=640&fit=crop 1x, https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=828&fit=crop 2x"',
+	);
+});
+
+test("supports an explicit height", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const img = renderJSON(<PrismicNextImage field={field} height="400" />);
+
+	expect(img?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=1080&fit=crop"',
+	);
+	expect(img?.props.srcSet).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=640&fit=crop 1x, https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=1080&fit=crop 2x"',
+	);
+});
+
+test("supports an explicit width and height", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const img = renderJSON(
+		<PrismicNextImage field={field} width="400" height="300" />,
+	);
+
+	expect(img?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=828&fit=crop"',
+	);
+	expect(img?.props.srcSet).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=640&fit=crop 1x, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=828&fit=crop 2x"',
+	);
+});
+
+test.only("handles a non-SafeNumber width and height", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const widthImg = renderJSON(
+		<PrismicNextImage
+			field={field}
+			// @ts-expect-error - We are purposely providing an invalid value.
+			width="NaN"
+		/>,
+	);
+	const heightImg = renderJSON(
+		<PrismicNextImage
+			field={field}
+			// @ts-expect-error - We are purposely providing an invalid value.
+			height="NaN"
+		/>,
+	);
+
+	expect(widthImg?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop"',
+	);
+	expect(heightImg?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1470770903676-69b98201ea1c?w=3840&fit=crop"',
+	);
+});
+
+test("supports sizes", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const img = renderJSON(
+		<PrismicNextImage
+			field={field}
+			sizes="(max-width: 768px) 100vw,
+				(max-width: 1200px) 50vw,
+				33vw"
+		/>,
+	);
+
+	expect(img?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=3840&fit=crop"',
+	);
+	expect(img?.props.srcSet).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=256&fit=crop 256w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=384&fit=crop 384w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=640&fit=crop 640w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=750&fit=crop 750w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=828&fit=crop 828w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=1080&fit=crop 1080w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=1200&fit=crop 1200w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=1920&fit=crop 1920w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=2048&fit=crop 2048w, https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=3840&fit=crop 3840w"',
+	);
+});
+
+test("supports quality", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const img = renderJSON(<PrismicNextImage field={field} quality={10} />);
+
+	expect(img?.props.src).toMatchInlineSnapshot(
+		'"https://images.unsplash.com/photo-1418065460487-3e41a6c84dc5?w=3840&fit=crop&q=10"',
+	);
+});
 
 test("uses the field's alt if given", (ctx) => {
 	const field = ctx.mock.value.image();
 	field.alt = "foo";
 
-	const res = renderJSON(<PrismicNextImage field={field} />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} />);
 
 	expect(img?.props.alt).toBe(field.alt);
 });
@@ -135,8 +135,7 @@ test("alt is undefined if the field does not have an alt value", (ctx) => {
 	const field = ctx.mock.value.image();
 	field.alt = null;
 
-	const res = renderJSON(<PrismicNextImage field={field} />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} />);
 
 	expect(img?.props.alt).toBe(undefined);
 });
@@ -145,8 +144,7 @@ test("supports an explicit decorative fallback alt value if given", (ctx) => {
 	const field = ctx.mock.value.image();
 	field.alt = null;
 
-	const res = renderJSON(<PrismicNextImage field={field} fallbackAlt="" />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} fallbackAlt="" />);
 
 	expect(img?.props.alt).toBe("");
 });
@@ -174,8 +172,7 @@ test("supports an explicit decorative alt when field has an alt value", (ctx) =>
 	const field = ctx.mock.value.image();
 	field.alt = "provided alt";
 
-	const res = renderJSON(<PrismicNextImage field={field} alt="" />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} alt="" />);
 
 	expect(img?.props.alt).toBe("");
 });
@@ -184,8 +181,7 @@ test("supports an explicit decorative alt when field does not have an alt value"
 	const field = ctx.mock.value.image();
 	field.alt = null;
 
-	const res = renderJSON(<PrismicNextImage field={field} alt="" />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} alt="" />);
 
 	expect(img?.props.alt).toBe("");
 });
@@ -209,13 +205,31 @@ test("warns if a non-decorative alt value is given", (ctx) => {
 	consoleWarnSpy.mockRestore();
 });
 
+test("supports the fill prop", (ctx) => {
+	const field = ctx.mock.value.image();
+
+	const img = renderJSON(<PrismicNextImage field={field} fill={true} />);
+
+	expect(img?.props.style).toStrictEqual(
+		expect.objectContaining({
+			position: "absolute",
+			top: 0,
+			right: 0,
+			bottom: 0,
+			left: 0,
+			width: "100%",
+			height: "100%",
+		}),
+	);
+});
+
 test("supports imgix parameters", (ctx) => {
 	const field = ctx.mock.value.image();
 
-	const res = renderJSON(
+	const img = renderJSON(
 		<PrismicNextImage field={field} imgixParams={{ sat: -100 }} />,
 	);
-	const img = getImg(res);
+
 	const src = new URL(img?.props.src);
 
 	expect(src.searchParams.get("sat")).toBe("-100");
@@ -227,8 +241,8 @@ test("applies fit=max by default", (ctx) => {
 	fieldURL.searchParams.delete("fit");
 	field.url = fieldURL.toString();
 
-	const res = renderJSON(<PrismicNextImage field={field} />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} />);
+
 	const src = new URL(img?.props.src);
 
 	expect(src.searchParams.get("fit")).toBe("max");
@@ -237,14 +251,14 @@ test("applies fit=max by default", (ctx) => {
 test("retains fit parameter if already included in the image url", (ctx) => {
 	const field = ctx.mock.value.image();
 	const fieldURL = new URL(field.url);
-	fieldURL.searchParams.set("fit", "crop");
+	fieldURL.searchParams.set("fit", "clamp");
 	field.url = fieldURL.toString();
 
-	const res = renderJSON(<PrismicNextImage field={field} />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} />);
+
 	const src = new URL(img?.props.src);
 
-	expect(src.searchParams.get("fit")).toBe("crop");
+	expect(src.searchParams.get("fit")).toBe("clamp");
 });
 
 test("allows overriding fit via imgixParams prop", (ctx) => {
@@ -253,10 +267,10 @@ test("allows overriding fit via imgixParams prop", (ctx) => {
 	fieldURL.searchParams.set("fit", "crop");
 	field.url = fieldURL.toString();
 
-	const res = renderJSON(
+	const img = renderJSON(
 		<PrismicNextImage field={field} imgixParams={{ fit: "facearea" }} />,
 	);
-	const img = getImg(res);
+
 	const src = new URL(img?.props.src);
 
 	expect(src.searchParams.get("fit")).toBe("facearea");
@@ -265,8 +279,7 @@ test("allows overriding fit via imgixParams prop", (ctx) => {
 test("allows falling back to the default loader", (ctx) => {
 	const field = ctx.mock.value.image();
 
-	const res = renderJSON(<PrismicNextImage field={field} loader={undefined} />);
-	const img = getImg(res);
+	const img = renderJSON(<PrismicNextImage field={field} loader={undefined} />);
 
 	expect(img?.props.src).toMatch(/^\/_next\/image\?url=/);
 });
@@ -274,14 +287,14 @@ test("allows falling back to the default loader", (ctx) => {
 test("supports imgix parameters when using the default loader", (ctx) => {
 	const field = ctx.mock.value.image();
 
-	const res = renderJSON(
+	const img = renderJSON(
 		<PrismicNextImage
 			field={field}
 			imgixParams={{ sat: -100 }}
 			loader={undefined}
 		/>,
 	);
-	const img = getImg(res);
+
 	const src = new URL(img?.props.src, "https://example.com");
 	const nextImageOptimizationAPIURL = new URL(
 		decodeURIComponent(src.searchParams.get("url") as string),
@@ -289,146 +302,3 @@ test("supports imgix parameters when using the default loader", (ctx) => {
 
 	expect(nextImageOptimizationAPIURL.searchParams.get("sat")).toBe("-100");
 });
-
-// describe("intrinsic layout (default)", () => {
-// 	test("supports automatic dimensiosn", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const res = renderJSON(<PrismicNextImage field={field} />);
-// 		const img = getImg(res);
-//
-// 		expect(img?.props.src).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop"',
-// 		);
-// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=828&fit=crop 1x, https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop 2x"',
-// 		);
-// 	});
-//
-// 	test("supports explicit width", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const res = renderJSON(<PrismicNextImage field={field} width="400" />);
-// 		const img = getImg(res);
-//
-// 		expect(img?.props.src).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop"',
-// 		);
-// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=640&fit=crop 1x, https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop 2x"',
-// 		);
-// 	});
-//
-// 	test("supports explicit height", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const res = renderJSON(<PrismicNextImage field={field} height="400" />);
-// 		const img = getImg(res);
-//
-// 		expect(img?.props.src).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop"',
-// 		);
-// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 1x, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 2x"',
-// 		);
-// 	});
-//
-// 	test("throws if invalid width or height is given", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const consoleErrorSpy = vi
-// 			.spyOn(console, "error")
-// 			.mockImplementation(() => void 0);
-//
-// 		expect(() => {
-// 			renderJSON(<PrismicNextImage field={field} width="NaN" height="NaN" />);
-// 		}).toThrow('invalid "width" or "height" property');
-//
-// 		consoleErrorSpy.mockRestore();
-// 	});
-// });
-//
-// describe("fixed layout", () => {
-// 	test("supports automatic dimensiosn", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const res = renderJSON(<PrismicNextImage field={field} layout="fixed" />);
-// 		const img = getImg(res);
-//
-// 		expect(img?.props.src).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop"',
-// 		);
-// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=828&fit=crop 1x, https://images.unsplash.com/photo-1604537466608-109fa2f16c3b?w=1920&fit=crop 2x"',
-// 		);
-// 	});
-//
-// 	test("supports explicit width", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const res = renderJSON(
-// 			<PrismicNextImage field={field} width="400" layout="fixed" />,
-// 		);
-// 		const img = getImg(res);
-//
-// 		expect(img?.props.src).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop"',
-// 		);
-// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=640&fit=crop 1x, https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=828&fit=crop 2x"',
-// 		);
-// 	});
-//
-// 	test("supports explicit height", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const res = renderJSON(
-// 			<PrismicNextImage field={field} height="400" layout="fixed" />,
-// 		);
-// 		const img = getImg(res);
-//
-// 		expect(img?.props.src).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop"',
-// 		);
-// 		expect(img?.props.srcSet).toMatchInlineSnapshot(
-// 			'"https://images.unsplash.com/photo-1444464666168-49d633b86797?w=640&fit=crop 1x, https://images.unsplash.com/photo-1444464666168-49d633b86797?w=1080&fit=crop 2x"',
-// 		);
-// 	});
-//
-// 	test("throws if invalid width or height is given", (ctx) => {
-// 		const field = ctx.mock.value.image();
-// 		field.dimensions.width = 800;
-// 		field.dimensions.height = 600;
-//
-// 		const consoleErrorSpy = vi
-// 			.spyOn(console, "error")
-// 			.mockImplementation(() => void 0);
-//
-// 		expect(() => {
-// 			renderJSON(
-// 				<PrismicNextImage
-// 					field={field}
-// 					width="NaN"
-// 					height="NaN"
-// 					layout="fixed"
-// 				/>,
-// 			);
-// 		}).toThrow('invalid "width" or "height" property');
-//
-// 		consoleErrorSpy.mockRestore();
-// 	});
-// });

--- a/test/__testutils__/renderJSON.ts
+++ b/test/__testutils__/renderJSON.ts
@@ -1,0 +1,24 @@
+import * as React from "react";
+import * as renderer from "react-test-renderer";
+
+/**
+ * Renders a JSON representation of a React.Element. This is a helper to reduce
+ * boilerplate in each test.
+ *
+ * @param element - The React.Element to render.
+ *
+ * @returns The JSON representation of `element`.
+ */
+export const renderJSON = (
+	element: React.ReactElement,
+	options?: renderer.TestRendererOptions,
+): renderer.ReactTestRendererJSON | null => {
+	let root: renderer.ReactTestRenderer;
+
+	renderer.act(() => {
+		root = renderer.create(element, options);
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	return root!.toJSON() as renderer.ReactTestRendererJSON;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for Next 13. It drops support for Next 12 (see **Reasoning for dropping Next 12 support** below).

### `<PrismicNextImage>` changes

- Adds support for Next 13's new `next/image` component with many improvements ([see the official list here](https://nextjs.org/docs/api-reference/next/legacy/image#comparison)).
- Adds a `fallback` prop used to define what is rendered when the given Image field is empty. It defaults to `null`.
- Drops support for Next 12's `next/image` `layout` prop. The new `next/image` component recommends using a combination of CSS, the `width` prop, the `height` prop, and the `fill` prop to style your images.

#### Migration steps

`<PrismicNextImage>` is a light wrapper around `next/image`. All `next/image` props are shared with `<PrismicNextImage>`, except the `src` prop since you use a `field` prop with an Image field instead.

[See Next.js's official migration guide here](https://nextjs.org/docs/advanced-features/codemods#next-image-experimental-experimental)

If you are using the `layout` prop with `<PrismicNextImage>` (which is passed directly to `next/image`), update your images's styling appropriately to support the new `next/image`.

#### Examples

```tsx
<PrismicNextImage field={myImageField} />
<PrismicNextImage field={myImageField} width={400} />
<PrismicNextImage field={myImageField} height={300} />
<PrismicNextImage field={myImageField} width={400} height={300} />

// All `next/image` props are supported.
<PrismicNextImage field={myImageField} fill={true} />
<PrismicNextImage
        field={myImageField}
        sizes="(max-width: 768px) 100vw,
                (max-width: 1200px) 50vw,
                33vw"
/>

// A fallback value can be provided.
<PrismicNextImage field={emptyField} fallback={<p>No image given!</p>} />
```

### Reasoning for dropping Next 12 support

1. Next 13 introduces a new `next/image` component which is not API-compatible with Next 12's `next/image` component.
2. Upgrading from Next 12 to Next 13 should be a straightforward upgrade. [See Next.js's official upgrade guide](https://nextjs.org/docs/upgrading).

If you are unable to upgrade your website to Next 13, stay on a previous version of `@prismicio/next` that supports Next 12. We recommend upgrading your project to Next 13 and the latest version of `@prismicio/next` as soon as you are able to.

### Support for Next.js's experimental `app` directory

The `app` directory with React Server Components is not currently supported. Please see this comment for more details: https://github.com/prismicio/prismic-next/pull/48#issuecomment-1316270169

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
