### PR TITLE
chore: remove `@prismicio/client` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/helpers": "^2.3.5",
+				"@prismicio/types": "^0.2.3",
 				"imgix-url-builder": "^0.0.3"
 			},
 			"devDependencies": {
 				"@prismicio/client": "^6.7.1",
 				"@prismicio/mock": "^0.1.1",
-				"@prismicio/types": "^0.2.3",
 				"@size-limit/preset-small-lib": "^8.1.0",
 				"@types/react-test-renderer": "^18.0.0",
 				"@typescript-eslint/eslint-plugin": "^5.40.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "0.1.7",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prismicio/client": "^6.7.1",
 				"@prismicio/helpers": "^2.3.5",
-				"@prismicio/types": "^0.2.3",
 				"imgix-url-builder": "^0.0.3"
 			},
 			"devDependencies": {
+				"@prismicio/client": "^6.7.1",
 				"@prismicio/mock": "^0.1.1",
+				"@prismicio/types": "^0.2.3",
 				"@size-limit/preset-small-lib": "^8.1.0",
 				"@types/react-test-renderer": "^18.0.0",
 				"@typescript-eslint/eslint-plugin": "^5.40.1",
@@ -46,7 +46,7 @@
 				"node": ">=14.15.0"
 			},
 			"peerDependencies": {
-				"@prismicio/client": "^6.0.0",
+				"@prismicio/client": "^6",
 				"next": "^11 || ^12",
 				"react": "^17 || ^18"
 			}
@@ -1053,6 +1053,7 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.7.1.tgz",
 			"integrity": "sha512-XIFSZtLjxnpQavu2R7jIqmnFvUqRRzHwjXHt/fb0N550rFLQM4tnwDuSR3VY6k/TG+M5zvH+PHJuXGNnv73qUQ==",
+			"dev": true,
 			"dependencies": {
 				"@prismicio/helpers": "^2.3.3",
 				"@prismicio/types": "^0.2.3"
@@ -9499,6 +9500,7 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.7.1.tgz",
 			"integrity": "sha512-XIFSZtLjxnpQavu2R7jIqmnFvUqRRzHwjXHt/fb0N550rFLQM4tnwDuSR3VY6k/TG+M5zvH+PHJuXGNnv73qUQ==",
+			"dev": true,
 			"requires": {
 				"@prismicio/helpers": "^2.3.3",
 				"@prismicio/types": "^0.2.3"

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
 		"unit:watch": "vitest watch"
 	},
 	"dependencies": {
-		"@prismicio/client": "^6.7.1",
 		"@prismicio/helpers": "^2.3.5",
-		"@prismicio/types": "^0.2.3",
 		"imgix-url-builder": "^0.0.3"
 	},
 	"devDependencies": {
+		"@prismicio/client": "^6.7.1",
 		"@prismicio/mock": "^0.1.1",
+		"@prismicio/types": "^0.2.3",
 		"@size-limit/preset-small-lib": "^8.1.0",
 		"@types/react-test-renderer": "^18.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.40.1",
@@ -80,7 +80,7 @@
 		"vitest": "^0.24.3"
 	},
 	"peerDependencies": {
-		"@prismicio/client": "^6.0.0",
+		"@prismicio/client": "^6",
 		"next": "^11 || ^12",
 		"react": "^17 || ^18"
 	},

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
 	},
 	"dependencies": {
 		"@prismicio/helpers": "^2.3.5",
+		"@prismicio/types": "^0.2.3",
 		"imgix-url-builder": "^0.0.3"
 	},
 	"devDependencies": {
 		"@prismicio/client": "^6.7.1",
 		"@prismicio/mock": "^0.1.1",
-		"@prismicio/types": "^0.2.3",
 		"@size-limit/preset-small-lib": "^8.1.0",
 		"@types/react-test-renderer": "^18.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.40.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR moves `@prismicio/client` from `dependencies` to `devDependencies`.

**Important**: `@prismicio/client` remains a peer dependency.

Thanks to @samuelhorn and @lihbr for diagnosing the issue!

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐭
