### PR TITLE
fix: resolve an issue where previews would not show if the default URL led to a 404 page

### DIFF
--- a/src/PrismicPreview.tsx
+++ b/src/PrismicPreview.tsx
@@ -68,7 +68,12 @@ export function PrismicPreview({
 			// Start Next.js Preview Mode via the given preview API endpoint.
 			const res = await globalThis.fetch(resolvedUpdatePreviewURL);
 
-			if (res.ok) {
+			// We check for `res.redirected` rather than `res.ok`
+			// since the update preview endpoint may redirect to a
+			// 404 page. As long as it redirects, we know the
+			// endpoint exists and at least attempted to set
+			// preview data.
+			if (res.redirected) {
 				globalThis.location.reload();
 			} else {
 				console.error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where preview content would not appear when using a shared preview link.

If `@prismicio/next`'s `redirectToPreviewURL()` `defaultURL` option pointed to a page that doesn't exist (i.e. a 404 status code), the page would not be refreshed. This happens because `<PrismicPreview>` checked for `res.ok` when fetching the `/api/preview` endpoint.

Rather than check for `res.ok`, which may result in a 404 despite properly updating preview data, `<PrismicPreview>` now checks that `res.redirected` is true.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐳
