### PR TITLE
fix(PrismicNextImage): use correct height dimension

### DIFF
--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -112,7 +112,7 @@ export const PrismicNextImage = ({
 		const castedHeight = castInt(height);
 
 		let resolvedWidth = castedWidth ?? field.dimensions.width;
-		let resolvedHeight = castedHeight ?? field.dimensions.width;
+		let resolvedHeight = castedHeight ?? field.dimensions.height;
 
 		if (castedWidth != null && castedHeight == null) {
 			resolvedHeight = castedWidth / ar;

--- a/test/PrismicNextImage.test.tsx
+++ b/test/PrismicNextImage.test.tsx
@@ -15,6 +15,8 @@ test("renders a NextImage for a given field", (ctx) => {
 	expect(img?.props.srcSet).toMatchInlineSnapshot(
 		'"https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=3840&fit=crop 1x"',
 	);
+	expect(img?.props.width).toBe(field.dimensions.width);
+	expect(img?.props.height).toBe(field.dimensions.height);
 });
 
 test("renders null when passed an empty field", (ctx) => {
@@ -48,19 +50,23 @@ test("supports an explicit width", (ctx) => {
 	expect(img?.props.srcSet).toMatchInlineSnapshot(
 		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=640&fit=crop 1x, https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=828&fit=crop 2x"',
 	);
+	expect(img?.props.width).toBe(400);
+	expect(img?.props.height).toBe(300);
 });
 
 test("supports an explicit height", (ctx) => {
 	const field = ctx.mock.value.image();
 
-	const img = renderJSON(<PrismicNextImage field={field} height="400" />);
+	const img = renderJSON(<PrismicNextImage field={field} height="600" />);
 
 	expect(img?.props.src).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=1080&fit=crop"',
+		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=1920&fit=crop"',
 	);
 	expect(img?.props.srcSet).toMatchInlineSnapshot(
-		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=640&fit=crop 1x, https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=1080&fit=crop 2x"',
+		'"https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=828&fit=crop 1x, https://images.unsplash.com/photo-1504567961542-e24d9439a724?w=1920&fit=crop 2x"',
 	);
+	expect(img?.props.width).toBe(800);
+	expect(img?.props.height).toBe(600);
 });
 
 test("supports an explicit width and height", (ctx) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `<PrismicNextImage>` used the given image's width for both the `width` and `height` dimensions.

Fixes: #55

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🙊
