### PR TITLE
feat: add experimental `prismic-next` CLI to clear Next.js fetch cache for Prismic requests

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -12,12 +12,24 @@ function getObjectValues(input, acc = []) {
 }
 
 module.exports = [
-	...new Set([pkg.main, pkg.module, ...getObjectValues(pkg.exports)]),
+	...new Set([
+		pkg.main,
+		pkg.module,
+		...getObjectValues(pkg.bin),
+		...getObjectValues(pkg.exports),
+	]),
 ]
 	.sort()
 	.filter((path) => {
 		return path && path !== "./package.json";
 	})
 	.map((path) => {
-		return { path };
+		return {
+			path,
+			modifyEsbuildConfig(config) {
+				config.platform = "node";
+
+				return config;
+			},
+		};
 	});

--- a/bin/prismic-next.js
+++ b/bin/prismic-next.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import("../dist/bin/prismic-next.cjs");

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
 				"imgix-url-builder": "^0.0.3",
 				"mri": "^1.2.0"
 			},
+			"bin": {
+				"prismic-next": "bin/prismic-next.js"
+			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.2.0",
 				"@size-limit/preset-small-lib": "^8.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/client": "^7.0.0-alpha.2",
-				"imgix-url-builder": "^0.0.3"
+				"imgix-url-builder": "^0.0.3",
+				"mri": "^1.2.0"
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.2.0",
@@ -5750,7 +5751,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
 			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -12066,8 +12066,7 @@
 		"mri": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-			"dev": true
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
 		},
 		"ms": {
 			"version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
 	},
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"bin": {
+		"prismic-next": "./bin/prismic-next.js"
+	},
 	"files": [
 		"dist",
 		"src"
@@ -52,8 +55,9 @@
 		"test": "npm run lint && npm run types && npm run unit && npm run build && npm run size"
 	},
 	"dependencies": {
-		"@prismicio/client": "^7.0.0-alpha.2",
-		"imgix-url-builder": "^0.0.3"
+		"@prismicio/client": "^6 || ^7",
+		"imgix-url-builder": "^0.0.3",
+		"mri": "^1.2.0"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"test": "npm run lint && npm run types && npm run unit && npm run build && npm run size"
 	},
 	"dependencies": {
-		"@prismicio/client": "^6 || ^7",
+		"@prismicio/client": "^7.0.0-alpha.2",
 		"imgix-url-builder": "^0.0.3",
 		"mri": "^1.2.0"
 	},

--- a/src/bin/prismic-next.ts
+++ b/src/bin/prismic-next.ts
@@ -1,0 +1,182 @@
+import mri from "mri";
+import path from "node:path";
+import fs from "node:fs";
+import tty from "node:tty";
+import { Buffer } from "node:buffer";
+
+import * as pkg from "../../package.json";
+
+type Args = {
+	help: boolean;
+	version: boolean;
+};
+
+const args = mri<Args>(process.argv.slice(2), {
+	boolean: ["help", "version"],
+	alias: {
+		help: "h",
+		version: "v",
+	},
+	default: {
+		help: false,
+		version: false,
+	},
+});
+
+const command = args._[0];
+
+async function run() {
+	switch (command) {
+		case "clear-cache": {
+			warn(
+				"`prismic-next clear-cache` is an experimental and unstable utility. It is provided as a temporary convenience until a more conventional cache cleaing solution is developed.",
+			);
+
+			function getAppRootDir() {
+				let currentDir = process.cwd();
+
+				while (
+					!fs.existsSync(path.join(currentDir, ".next")) ||
+					!fs.existsSync(path.join(currentDir, "package.json"))
+				) {
+					currentDir = path.join(currentDir, "..");
+				}
+
+				if (
+					fs.existsSync(path.join(currentDir, ".next")) ||
+					fs.existsSync(path.join(currentDir, "package.json"))
+				) {
+					return currentDir;
+				}
+			}
+
+			const appRootDir = getAppRootDir();
+
+			if (!appRootDir) {
+				warn(
+					"Could not find the Next.js app root. Run `prismic-next clear-cache` in a Next.js project with a `.next` directory or `package.json` file.",
+				);
+
+				process.exit();
+			}
+
+			const fetchCacheDir = path.join(
+				appRootDir,
+				".next",
+				"cache",
+				"fetch-cache",
+			);
+
+			if (!fs.existsSync(fetchCacheDir)) {
+				info("No Next.js fetch cache directory found. You are good to go!");
+
+				process.exit();
+			}
+
+			const cacheEntries = fs.readdirSync(fetchCacheDir);
+
+			await Promise.all(
+				cacheEntries.map(async (entry) => {
+					try {
+						const contents = fs.readFileSync(
+							path.join(fetchCacheDir, entry),
+							"utf8",
+						);
+						const payload = JSON.parse(contents);
+						const bodyPayload = JSON.parse(
+							Buffer.from(payload.data.body, "base64").toString(),
+						);
+
+						// Delete `/api/v2` requests.
+						if (/\.prismic\.io\/auth$/.test(bodyPayload.oauth_initiate)) {
+							fs.unlinkSync(path.join(fetchCacheDir, entry));
+
+							info(`Prismic /api/v2 request cache cleared: ${entry}`);
+						}
+					} catch (e) {
+						// noop
+					}
+				}),
+			);
+
+			info(
+				"The Prismic request cache has been cleared. Uncached requests will begin on the next Next.js server start-up.",
+			);
+
+			process.exit();
+		}
+
+		default: {
+			if (command && (!args.version || !args.help)) {
+				console.info("Invalid command.\n");
+			}
+
+			if (args.version) {
+				console.info(pkg.version);
+
+				process.exit();
+			}
+
+			console.info(
+				`
+Usage:
+    prismic-next <command> [options...]
+
+Available commands:
+    clear-cache
+
+Options:
+    --help, -h     Show help text
+    --version, -v  Show version
+`.trim(),
+			);
+
+			process.exit();
+		}
+	}
+}
+
+run();
+
+/**
+ * The following code was adapted from
+ * https://github.com/sindresorhus/yoctocolors
+ *
+ * MIT License
+ *
+ * Copyright (c) Sindre Sorhus (https://sindresorhus.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//
+function color(color: "yellow" | "magenta", string: string) {
+	const hasColors = tty.WriteStream.prototype.hasColors();
+
+	const startCode = color === "yellow" ? 33 : 35;
+
+	return hasColors
+		? "\u001B[" + startCode + "m" + string + "\u001B[39m"
+		: string;
+}
+function warn(string: string) {
+	return console.warn(`${color("yellow", "warn")}  - ${string}`);
+}
+function info(string: string) {
+	return console.info(`${color("magenta", "info")}  - ${string}`);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 			entry: {
 				index: "./src/index.ts",
 				"react-server": "./src/react-server/index.ts",
+				"bin/prismic-next": "./src/bin/prismic-next.ts",
 			},
 		},
 		rollupOptions: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a `prismic-next` CLI to `@prismicio/next` to be used with Next.js 13 and App Router. Projects with `@prismicio/next` will automatically have the `prismic-next` CLI available.

The CLI contains one command: `clear-cache`. The command clears Next.js' fetch cache of any `/api/v2` requests, which effectively allows a site refetch fresh content from Prismic.

> **Warning**: The command is experiemental and unstable. It is provided as a temporary convenience until a more conventional cache cleaing solution is developed.

`prismic-next clear-cache` should be run before every `next dev` and `next build` command:

```jsonc
// package.json

{
  "scripts": {
    "dev": "prismic-next clear-cache && next dev",
    "build": "prismic-next clear-cache && next build"
  }
}
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐯
