### PR TITLE
fix(PrismicNextImage): log error if no alternative text is available (only in non-production environments)

### DIFF
--- a/src/lib/__PRODUCTION__.ts
+++ b/src/lib/__PRODUCTION__.ts
@@ -1,7 +1,0 @@
-/**
- * `true` if in the production environment, `false` otherwise.
- *
- * This boolean can be used to perform actions only in development environments,
- * such as logging.
- */
-export const __PRODUCTION__ = process.env.NODE_ENV === "production";

--- a/test/PrismicNextImage.test.tsx
+++ b/test/PrismicNextImage.test.tsx
@@ -157,9 +157,15 @@ test("alt is undefined if the field does not have an alt value", (ctx) => {
 	const field = ctx.mock.value.image();
 	field.alt = null;
 
+	const consoleErrorSpy = vi
+		.spyOn(console, "error")
+		.mockImplementation(() => void 0);
+
 	const img = renderJSON(<PrismicNextImage field={field} />);
 
 	expect(img?.props.alt).toBe(undefined);
+
+	consoleErrorSpy.mockRestore();
 });
 
 test("supports an explicit decorative fallback alt value if given", (ctx) => {
@@ -225,6 +231,24 @@ test("warns if a non-decorative alt value is given", (ctx) => {
 	);
 
 	consoleWarnSpy.mockRestore();
+});
+
+test("logs error if no alt text is available", (ctx) => {
+	const field = ctx.mock.value.image();
+	field.alt = null;
+
+	const consoleErrorSpy = vi
+		.spyOn(console, "error")
+		.mockImplementation(() => void 0);
+
+	renderJSON(<PrismicNextImage field={field} />);
+
+	expect(consoleErrorSpy).toHaveBeenCalledWith(
+		expect.stringMatching(/missing an "alt" property/),
+		field.url,
+	);
+
+	consoleErrorSpy.mockRestore();
 });
 
 test("supports the fill prop", (ctx) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a non-production error when `<PrismicNextImage>` does not have an available `alt` value.

`<PrismicNextImage>` uses the following priority to determine its `alt` value:

1. Its `alt` prop (`""` is the only valid value)
1. The image field's `alt` property (set in Prismic)
1. Its `fallbackAlt` prop (`""` is the only valid value)

The error recommends setting Alternative Text in Prismic along with instructions on marking the image as decorative, if desired.

```
[PrismicNextImage] The following image is missing an "alt" property. Please add Alternative Text to the image in Prismic. To mark the image as decorative instead, add one of \`alt=""\` or \`fallbackAlt=""\`.
```

This error message is displayed just before `next/image`'s built-in error which is logged in the same case as the above message. There is no way to disable the `next/image` error without providing an alt value, so this PR lets both errors log.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐺
