### PR TITLE
fix(PrismicPreview): prevent "missing `requestAsyncStorage`" error in the Pages Router

### DIFF
--- a/src/PrismicPreview.tsx
+++ b/src/PrismicPreview.tsx
@@ -52,7 +52,15 @@ export function PrismicPreview({
 	...props
 }: PrismicPreviewProps): JSX.Element {
 	const toolbarSrc = prismic.getToolbarSrc(repositoryName);
-	const isDraftMode = draftMode().isEnabled;
+
+	let isDraftMode = false;
+	try {
+		isDraftMode = draftMode().isEnabled;
+	} catch {
+		// noop - `requestAsyncStorage` propbably doesn't exist, such as
+		// in the Pages Router, which causes `draftMode()` to throw. We
+		// can ignore this case and assume Draft Mode is disabled.
+	}
 
 	return (
 		<>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where using `<PrismicPreview>` in the Pages Router caused the following error to throw:

```
Method expects to have requestAsyncStorage, none available
```

This error is triggered by the internal use of `draftMode()`, which is only supported in the App Router.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
