### PR TITLE
fix(exitPreview): prevent "Cannot set headers after they are sent to the client" warning in the Pages Router

### DIFF
--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -57,18 +57,16 @@ export type ExitPreviewConfig = {
  * }
  * ```
  */
-export async function exitPreview(
-	config?: ExitPreviewConfig,
-): Promise<Response | void> {
+export function exitPreview(config?: ExitPreviewConfig): Response | void {
 	if (config?.res) {
 		// Assume Preview Mode is being used.
 
 		config.res.clearPreviewData();
 
-		// 205 status is used to prevent CDN-level caching. The default 200
-		// status code is typically treated as non-changing and cacheable.
-		config.res.json({ success: true });
+		// `Cache-Control` header is used to prevent CDN-level caching.
 		config.res.setHeader("Cache-Control", "no-store");
+
+		config.res.json({ success: true });
 
 		return;
 	} else {
@@ -76,8 +74,7 @@ export async function exitPreview(
 
 		draftMode().disable();
 
-		// 205 status is used to prevent CDN-level caching. The default 200
-		// status code is typically treated as non-changing and cacheable.
+		// `Cache-Control` header is used to prevent CDN-level caching.
 		return new Response(JSON.stringify({ success: true }), {
 			headers: {
 				"Cache-Control": "no-store",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `exitPreview()` tirggered the following warning when used in the Pages Router:

```
Cannot set headers after they are sent to the client
```

This warning was triggered by calling `res.setHeader()` after `res.json()`, which is not allowed.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
