### PR TITLE
fix(PrismicNextImage): allow removing Imgix params in React Server Components using `null`

### DIFF
--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -33,7 +33,7 @@ export type PrismicNextImageProps = Omit<ImageProps, "src" | "alt"> & {
 	 *
 	 * @see https://docs.imgix.com/apis/rendering
 	 */
-	imgixParams?: ImgixURLParams;
+	imgixParams?: { [P in keyof ImgixURLParams]: ImgixURLParams[P] | null };
 
 	/**
 	 * Declare an image as decorative by providing `alt=""`.
@@ -104,7 +104,14 @@ export const PrismicNextImage = ({
 	}
 
 	if (prismic.isFilled.imageThumbnail(field)) {
-		const src = buildURL(field.url, imgixParams);
+		const resolvedImgixParams = imgixParams;
+		for (const x in imgixParams) {
+			if (resolvedImgixParams[x as keyof typeof resolvedImgixParams] === null) {
+				resolvedImgixParams[x as keyof typeof resolvedImgixParams] = undefined;
+			}
+		}
+
+		const src = buildURL(field.url, imgixParams as ImgixURLParams);
 
 		const ar = field.dimensions.width / field.dimensions.height;
 

--- a/test/PrismicNextImage.test.tsx
+++ b/test/PrismicNextImage.test.tsx
@@ -322,6 +322,35 @@ test("allows overriding fit via imgixParams prop", (ctx) => {
 	expect(src.searchParams.get("fit")).toBe("facearea");
 });
 
+test("allows removing existing Imgix params via the imgixParams prop", (ctx) => {
+	const field = ctx.mock.value.image();
+	const fieldURL = new URL(field.url);
+	fieldURL.searchParams.set("auto", "compress,format");
+	fieldURL.searchParams.set("sat", "-100");
+	fieldURL.searchParams.set("ar", "1:2");
+	field.url = fieldURL.toString();
+
+	const img = renderJSON(
+		<PrismicNextImage
+			field={field}
+			sizes="100vw"
+			imgixParams={{
+				auto: undefined,
+				// React Server Components removes `undefined`
+				// from objects, so we also support `null` as an
+				// explicit value to remove a param.
+				sat: null,
+			}}
+		/>,
+	);
+
+	const src = new URL(img?.props.src);
+
+	expect(src.searchParams.get("auto")).toBe(null);
+	expect(src.searchParams.get("sat")).toBe(null);
+	expect(src.searchParams.get("ar")).toBe("1:2");
+});
+
 test("allows falling back to the default loader", (ctx) => {
 	const field = ctx.mock.value.image();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a case where `<PrismicNextImage>` would not remove Imgix parameters when used in React Server Components (RSC).

RSCs serialize prop values before sending to Client Compomnents like `<PrismicNextImage>`. During this serialization, `undefined` values are removed from objects, which `<PrismicNextImage>`'s underlying Imgix param library, `imgix-url-builder`, relies on to remove parameters.

To fix this, `imgixParams` now accepts `null` in place of `undefined`.

**`null` should be used to remove parameters when `<PrismicNextImage>` is used in Server Components.**

```tsx
// In a Server Component
<PrismicNextImage
  field={myImageField}
  imgixParams={{
    auto: null, // undefined will not work
  }}
/>
```

```tsx
// In a Client Component
<PrismicNextImage
  field={myImageField}
  imgixParams={{
    auto: undefined, // null can also be used
  }}
/>
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
