### PR TITLE
fix: prevent `<PrismicNextImage>` "Element type is invalid" error

### DIFF
--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -142,8 +142,15 @@ export const PrismicNextImage = ({
 			);
 		}
 
+		// TODO: Remove once https://github.com/vercel/next.js/issues/52216 is resolved.
+		// `next/image` seems to be affected by a default + named export bundling bug.
+		let ResolvedImage = Image;
+		if ("default" in ResolvedImage) {
+			ResolvedImage = ResolvedImage.default as typeof Image;
+		}
+
 		return (
-			<Image
+			<ResolvedImage
 				src={src}
 				width={fill ? undefined : resolvedWidth}
 				height={fill ? undefined : resolvedHeight}

--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -146,7 +146,7 @@ export const PrismicNextImage = ({
 		// `next/image` seems to be affected by a default + named export bundling bug.
 		let ResolvedImage = Image;
 		if ("default" in ResolvedImage) {
-			ResolvedImage = ResolvedImage.default as typeof Image;
+			ResolvedImage = (ResolvedImage as { default: typeof Image }).default;
 		}
 
 		return (

--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -146,7 +146,8 @@ export const PrismicNextImage = ({
 		// `next/image` seems to be affected by a default + named export bundling bug.
 		let ResolvedImage = Image;
 		if ("default" in ResolvedImage) {
-			ResolvedImage = (ResolvedImage as { default: typeof Image }).default;
+			ResolvedImage = (ResolvedImage as unknown as { default: typeof Image })
+				.default;
 		}
 
 		return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes an issue in `<PrismicNextImage>` where Next.js would throw an "Element type is invalid" error upon server rendering the component.

The bug seems to come from Next.js itself, since `<PrismicNextImage>`'s code has not been modified recently.

The code in this PR should be removed once the underlying issue in Next.js is fixed.

Related issue: https://github.com/vercel/next.js/issues/52216

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐈
