### PR TITLE
fix(redirectToPreviewURL): support unpublished previews in the App Router

### DIFF
--- a/src/redirectToPreviewURL.ts
+++ b/src/redirectToPreviewURL.ts
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
-import type * as prismic from "@prismicio/client";
+import { cookies, draftMode } from "next/headers";
+import * as prismic from "@prismicio/client";
 
 import {
 	NextApiRequestLike,
@@ -92,6 +93,18 @@ export async function redirectToPreviewURL(
 	});
 
 	if ("nextUrl" in request) {
+		draftMode().enable();
+
+		// Set the initial preview cookie, if available.
+		// Setting the cookie here is necessary to support unpublished
+		// previews. Without setting it here, the page will try to
+		// render without the preview cookie, leading to a
+		// PrismicNotFound error.
+		const previewCookie = request.nextUrl.searchParams.get("token");
+		if (previewCookie) {
+			cookies().set(prismic.cookie.preview, previewCookie);
+		}
+
 		redirect(basePath + previewUrl);
 	} else {
 		if (!("res" in config)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,11 @@ export type NextRequestLike = {
 		get(name: string): string | null;
 	};
 	url: string;
-	nextUrl: unknown;
+	nextUrl: {
+		searchParams: {
+			get(name: string): string | null;
+		};
+	};
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where unpublished previews were not able to load when using the App Router.

`redirectToPreviewURL()` now does the following:

- Enables Draft Mode automatically via `draftMode().enable()`.
- Sets the Prismic preview cookie immediately, allowing unpublished documents to be previewed.

**No changes are required to projects' existing `/api/preview` endpoint**.

If desired, you may remove `draftMode().enable()` from your `/app/api/preview/route.js` file.

```diff
// /app/api/preview/route.js

  import { redirectToPreviewURL } from "@prismicio/next";
- import { draftMode } from "next/headers";
  import { createClient } from "@/prismicio";

  export async function GET(request) {
    const client = createClient();

-   draftMode().enable()

    await redirectToPreviewURL({ client, request });
  }
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐷
