### PR TITLE
fix: prevent `next build` TypeScript errors from `redirectToPreviewURL()` and `exitPreview()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"imgix-url-builder": "^0.0.4"
 			},
 			"devDependencies": {
-				"@prismicio/client": "^7.1.0",
+				"@prismicio/client": "^7.2.0",
 				"@prismicio/mock": "^0.3.0",
 				"@size-limit/preset-small-lib": "^8.2.4",
 				"@types/react-test-renderer": "^18.0.0",
@@ -28,7 +28,7 @@
 				"eslint-plugin-tsdoc": "^0.2.17",
 				"happy-dom": "^9.20.3",
 				"memfs": "^3.5.3",
-				"next": "^13.4.5-canary.9",
+				"next": "^13.5.2",
 				"node-fetch": "^3.3.1",
 				"prettier": "^2.8.8",
 				"prettier-plugin-jsdoc": "^0.4.2",
@@ -990,15 +990,15 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5.tgz",
-			"integrity": "sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.2.tgz",
+			"integrity": "sha512-dUseBIQVax+XtdJPzhwww4GetTjlkRSsXeQnisIJWBaHsnxYcN2RGzsPHi58D6qnkATjnhuAtQTJmR1hKYQQPg==",
 			"dev": true
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz",
-			"integrity": "sha512-XvTzi2ASUN5bECFIAAcBiSoDb0xsq+KLj4F0bof4d4rdc+FgOqLvseGQaOXwVi1TIh5bHa7o4b6droSJMO5+2g==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.2.tgz",
+			"integrity": "sha512-7eAyunAWq6yFwdSQliWMmGhObPpHTesiKxMw4DWVxhm5yLotBj8FCR4PXGkpRP2tf8QhaWuVba+/fyAYggqfQg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1012,9 +1012,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5.tgz",
-			"integrity": "sha512-NQdqal/VKAqlJTuzhjZmNtdo8QSqwmfO7b2xJSAengTEVxQvsH76oGEzQeIv8Ci4NP6DysAFtFrJq++TmIxcUA==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.2.tgz",
+			"integrity": "sha512-WxXYWE7zF1ch8rrNh5xbIWzhMVas6Vbw+9BCSyZvu7gZC5EEiyZNJsafsC89qlaSA7BnmsDXVWQmc+s1feSYbQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1028,9 +1028,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5.tgz",
-			"integrity": "sha512-nB8TjtpJCXtzIFjYOMbnQu68ajkA8QK58TreHjTGojSQjsF0StDqo5zFHglVVVHrd8d3N/+EjC18yFNSWnd/ZA==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.2.tgz",
+			"integrity": "sha512-URSwhRYrbj/4MSBjLlefPTK3/tvg95TTm6mRaiZWBB6Za3hpHKi8vSdnCMw5D2aP6k0sQQIEG6Pzcfwm+C5vrg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1044,9 +1044,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5.tgz",
-			"integrity": "sha512-W126XUW599OV3giSH9Co40VpT8VAOT47xONVHXZaYEpeca0qEevjj6WUr5IJu/8u+XGWm5xI1S0DYWjR6W+olw==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.2.tgz",
+			"integrity": "sha512-HefiwAdIygFyNmyVsQeiJp+j8vPKpIRYDlmTlF9/tLdcd3qEL/UEBswa1M7cvO8nHcr27ZTKXz5m7dkd56/Esg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1060,9 +1060,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5.tgz",
-			"integrity": "sha512-ZbPLO/oztQdtjGmWvGhRmtkZ6j9kQqg65kiO7F7Ijj7ojTtu3hh/vY+XRsHa/4Cse6HgyJ8XGZJMGoLb8ecQfQ==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.2.tgz",
+			"integrity": "sha512-htGVVroW0tdHgMYwKWkxWvVoG2RlAdDXRO1RQxYDvOBQsaV0nZsgKkw0EJJJ3urTYnwKskn/MXm305cOgRxD2w==",
 			"cpu": [
 				"x64"
 			],
@@ -1076,9 +1076,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5.tgz",
-			"integrity": "sha512-f+/h8KMNixVUoRB+2vza8I+jsthJ4KcvopGUsDIUHe7Q4t+m8nKwGFBeyNu9qNIenYK5g5QYEsSwYFEqZylrTQ==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.2.tgz",
+			"integrity": "sha512-UBD333GxbHVGi7VDJPPDD1bKnx30gn2clifNJbla7vo5nmBV+x5adyARg05RiT9amIpda6yzAEEUu+s774ldkw==",
 			"cpu": [
 				"x64"
 			],
@@ -1092,9 +1092,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5.tgz",
-			"integrity": "sha512-dvtPQZ5+J+zUE1uq7gP853Oj63e+n0T1ydZ/yRdVh7d8zW9ZFuC9fFrg3MqP1cv1NPPur8rrTqDKN2mRBkSSBw==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.2.tgz",
+			"integrity": "sha512-Em9ApaSFIQnWXRT3K6iFnr9uBXymixLc65Xw4eNt7glgH0eiXpg+QhjmgI2BFyc7k4ZIjglfukt9saNpEyolWA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1108,9 +1108,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5.tgz",
-			"integrity": "sha512-gK9zwGe25x31S4AjPy3Bf2niQvHIAbmwgkzmqWG3OmD4K2Z/Dh2ju4vuyzPzIt0pwQe4B520meP9NizTBmVWSg==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.2.tgz",
+			"integrity": "sha512-TBACBvvNYU+87X0yklSuAseqdpua8m/P79P0SG1fWUvWDDA14jASIg7kr86AuY5qix47nZLEJ5WWS0L20jAUNw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1124,9 +1124,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5.tgz",
-			"integrity": "sha512-iyNQVc7eGehrik9RJt9xGcnO6b/pi8C7GCfg8RGenx1IlalEKbYRgBJloF7DQzwlrV47E9bQl8swT+JawaNcKA==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.2.tgz",
+			"integrity": "sha512-LfTHt+hTL8w7F9hnB3H4nRasCzLD/fP+h4/GUVBTxrkMJOnh/7OZ0XbYDKO/uuWwryJS9kZjhxcruBiYwc5UDw==",
 			"cpu": [
 				"x64"
 			],
@@ -1175,25 +1175,16 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.1.0.tgz",
-			"integrity": "sha512-9UvPjPae+7KfdZpUvdDCQG+9GCrR/A0BVFrixj1O7lv7SCJuyp50ZIVm9cc6G49E0HMSHFH592isRKj/xKjP+w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.2.0.tgz",
+			"integrity": "sha512-bfbs2ZMLd3ba7Bp1qI4qAz+13FIWE/JDT9+h+3hL/MVpK4iDpjz3vmOlYJs25myhryU9HP8Og7qKoaeE9hPzmA==",
 			"dev": true,
 			"dependencies": {
 				"@prismicio/richtext": "^2.1.5",
-				"imgix-url-builder": "^0.0.3"
+				"imgix-url-builder": "^0.0.4"
 			},
 			"engines": {
 				"node": ">=14.15.0"
-			}
-		},
-		"node_modules/@prismicio/client/node_modules/imgix-url-builder": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz",
-			"integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.7.0"
 			}
 		},
 		"node_modules/@prismicio/mock": {
@@ -1342,9 +1333,9 @@
 			}
 		},
 		"node_modules/@swc/helpers": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-			"integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
@@ -5950,13 +5941,13 @@
 			"dev": true
 		},
 		"node_modules/next": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/next/-/next-13.4.5.tgz",
-			"integrity": "sha512-pfNsRLVM9e5Y1/z02VakJRfD6hMQkr24FaN2xc9GbcZDBxoOgiNAViSg5cXwlWCoMhtm4U315D7XYhgOr96Q3Q==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/next/-/next-13.5.2.tgz",
+			"integrity": "sha512-vog4UhUaMYAzeqfiAAmgB/QWLW7p01/sg+2vn6bqc/CxHFYizMzLv6gjxKzl31EVFkfl/F+GbxlKizlkTE9RdA==",
 			"dev": true,
 			"dependencies": {
-				"@next/env": "13.4.5",
-				"@swc/helpers": "0.5.1",
+				"@next/env": "13.5.2",
+				"@swc/helpers": "0.5.2",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001406",
 				"postcss": "8.4.14",
@@ -5968,31 +5959,27 @@
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": ">=16.8.0"
+				"node": ">=16.14.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "13.4.5",
-				"@next/swc-darwin-x64": "13.4.5",
-				"@next/swc-linux-arm64-gnu": "13.4.5",
-				"@next/swc-linux-arm64-musl": "13.4.5",
-				"@next/swc-linux-x64-gnu": "13.4.5",
-				"@next/swc-linux-x64-musl": "13.4.5",
-				"@next/swc-win32-arm64-msvc": "13.4.5",
-				"@next/swc-win32-ia32-msvc": "13.4.5",
-				"@next/swc-win32-x64-msvc": "13.4.5"
+				"@next/swc-darwin-arm64": "13.5.2",
+				"@next/swc-darwin-x64": "13.5.2",
+				"@next/swc-linux-arm64-gnu": "13.5.2",
+				"@next/swc-linux-arm64-musl": "13.5.2",
+				"@next/swc-linux-x64-gnu": "13.5.2",
+				"@next/swc-linux-x64-musl": "13.5.2",
+				"@next/swc-win32-arm64-msvc": "13.5.2",
+				"@next/swc-win32-ia32-msvc": "13.5.2",
+				"@next/swc-win32-x64-msvc": "13.5.2"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
-				"fibers": ">= 3.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
-					"optional": true
-				},
-				"fibers": {
 					"optional": true
 				},
 				"sass": {
@@ -8943,71 +8930,71 @@
 			}
 		},
 		"@next/env": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5.tgz",
-			"integrity": "sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.2.tgz",
+			"integrity": "sha512-dUseBIQVax+XtdJPzhwww4GetTjlkRSsXeQnisIJWBaHsnxYcN2RGzsPHi58D6qnkATjnhuAtQTJmR1hKYQQPg==",
 			"dev": true
 		},
 		"@next/swc-darwin-arm64": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz",
-			"integrity": "sha512-XvTzi2ASUN5bECFIAAcBiSoDb0xsq+KLj4F0bof4d4rdc+FgOqLvseGQaOXwVi1TIh5bHa7o4b6droSJMO5+2g==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.2.tgz",
+			"integrity": "sha512-7eAyunAWq6yFwdSQliWMmGhObPpHTesiKxMw4DWVxhm5yLotBj8FCR4PXGkpRP2tf8QhaWuVba+/fyAYggqfQg==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-darwin-x64": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5.tgz",
-			"integrity": "sha512-NQdqal/VKAqlJTuzhjZmNtdo8QSqwmfO7b2xJSAengTEVxQvsH76oGEzQeIv8Ci4NP6DysAFtFrJq++TmIxcUA==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.2.tgz",
+			"integrity": "sha512-WxXYWE7zF1ch8rrNh5xbIWzhMVas6Vbw+9BCSyZvu7gZC5EEiyZNJsafsC89qlaSA7BnmsDXVWQmc+s1feSYbQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-arm64-gnu": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5.tgz",
-			"integrity": "sha512-nB8TjtpJCXtzIFjYOMbnQu68ajkA8QK58TreHjTGojSQjsF0StDqo5zFHglVVVHrd8d3N/+EjC18yFNSWnd/ZA==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.2.tgz",
+			"integrity": "sha512-URSwhRYrbj/4MSBjLlefPTK3/tvg95TTm6mRaiZWBB6Za3hpHKi8vSdnCMw5D2aP6k0sQQIEG6Pzcfwm+C5vrg==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-arm64-musl": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5.tgz",
-			"integrity": "sha512-W126XUW599OV3giSH9Co40VpT8VAOT47xONVHXZaYEpeca0qEevjj6WUr5IJu/8u+XGWm5xI1S0DYWjR6W+olw==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.2.tgz",
+			"integrity": "sha512-HefiwAdIygFyNmyVsQeiJp+j8vPKpIRYDlmTlF9/tLdcd3qEL/UEBswa1M7cvO8nHcr27ZTKXz5m7dkd56/Esg==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-x64-gnu": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5.tgz",
-			"integrity": "sha512-ZbPLO/oztQdtjGmWvGhRmtkZ6j9kQqg65kiO7F7Ijj7ojTtu3hh/vY+XRsHa/4Cse6HgyJ8XGZJMGoLb8ecQfQ==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.2.tgz",
+			"integrity": "sha512-htGVVroW0tdHgMYwKWkxWvVoG2RlAdDXRO1RQxYDvOBQsaV0nZsgKkw0EJJJ3urTYnwKskn/MXm305cOgRxD2w==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-linux-x64-musl": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5.tgz",
-			"integrity": "sha512-f+/h8KMNixVUoRB+2vza8I+jsthJ4KcvopGUsDIUHe7Q4t+m8nKwGFBeyNu9qNIenYK5g5QYEsSwYFEqZylrTQ==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.2.tgz",
+			"integrity": "sha512-UBD333GxbHVGi7VDJPPDD1bKnx30gn2clifNJbla7vo5nmBV+x5adyARg05RiT9amIpda6yzAEEUu+s774ldkw==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-win32-arm64-msvc": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5.tgz",
-			"integrity": "sha512-dvtPQZ5+J+zUE1uq7gP853Oj63e+n0T1ydZ/yRdVh7d8zW9ZFuC9fFrg3MqP1cv1NPPur8rrTqDKN2mRBkSSBw==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.2.tgz",
+			"integrity": "sha512-Em9ApaSFIQnWXRT3K6iFnr9uBXymixLc65Xw4eNt7glgH0eiXpg+QhjmgI2BFyc7k4ZIjglfukt9saNpEyolWA==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-win32-ia32-msvc": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5.tgz",
-			"integrity": "sha512-gK9zwGe25x31S4AjPy3Bf2niQvHIAbmwgkzmqWG3OmD4K2Z/Dh2ju4vuyzPzIt0pwQe4B520meP9NizTBmVWSg==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.2.tgz",
+			"integrity": "sha512-TBACBvvNYU+87X0yklSuAseqdpua8m/P79P0SG1fWUvWDDA14jASIg7kr86AuY5qix47nZLEJ5WWS0L20jAUNw==",
 			"dev": true,
 			"optional": true
 		},
 		"@next/swc-win32-x64-msvc": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5.tgz",
-			"integrity": "sha512-iyNQVc7eGehrik9RJt9xGcnO6b/pi8C7GCfg8RGenx1IlalEKbYRgBJloF7DQzwlrV47E9bQl8swT+JawaNcKA==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.2.tgz",
+			"integrity": "sha512-LfTHt+hTL8w7F9hnB3H4nRasCzLD/fP+h4/GUVBTxrkMJOnh/7OZ0XbYDKO/uuWwryJS9kZjhxcruBiYwc5UDw==",
 			"dev": true,
 			"optional": true
 		},
@@ -9038,21 +9025,13 @@
 			}
 		},
 		"@prismicio/client": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.1.0.tgz",
-			"integrity": "sha512-9UvPjPae+7KfdZpUvdDCQG+9GCrR/A0BVFrixj1O7lv7SCJuyp50ZIVm9cc6G49E0HMSHFH592isRKj/xKjP+w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.2.0.tgz",
+			"integrity": "sha512-bfbs2ZMLd3ba7Bp1qI4qAz+13FIWE/JDT9+h+3hL/MVpK4iDpjz3vmOlYJs25myhryU9HP8Og7qKoaeE9hPzmA==",
 			"dev": true,
 			"requires": {
 				"@prismicio/richtext": "^2.1.5",
-				"imgix-url-builder": "^0.0.3"
-			},
-			"dependencies": {
-				"imgix-url-builder": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz",
-					"integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==",
-					"dev": true
-				}
+				"imgix-url-builder": "^0.0.4"
 			}
 		},
 		"@prismicio/mock": {
@@ -9143,9 +9122,9 @@
 			}
 		},
 		"@swc/helpers": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-			"integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.4.0"
@@ -12493,22 +12472,22 @@
 			"dev": true
 		},
 		"next": {
-			"version": "13.4.5",
-			"resolved": "https://registry.npmjs.org/next/-/next-13.4.5.tgz",
-			"integrity": "sha512-pfNsRLVM9e5Y1/z02VakJRfD6hMQkr24FaN2xc9GbcZDBxoOgiNAViSg5cXwlWCoMhtm4U315D7XYhgOr96Q3Q==",
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/next/-/next-13.5.2.tgz",
+			"integrity": "sha512-vog4UhUaMYAzeqfiAAmgB/QWLW7p01/sg+2vn6bqc/CxHFYizMzLv6gjxKzl31EVFkfl/F+GbxlKizlkTE9RdA==",
 			"dev": true,
 			"requires": {
-				"@next/env": "13.4.5",
-				"@next/swc-darwin-arm64": "13.4.5",
-				"@next/swc-darwin-x64": "13.4.5",
-				"@next/swc-linux-arm64-gnu": "13.4.5",
-				"@next/swc-linux-arm64-musl": "13.4.5",
-				"@next/swc-linux-x64-gnu": "13.4.5",
-				"@next/swc-linux-x64-musl": "13.4.5",
-				"@next/swc-win32-arm64-msvc": "13.4.5",
-				"@next/swc-win32-ia32-msvc": "13.4.5",
-				"@next/swc-win32-x64-msvc": "13.4.5",
-				"@swc/helpers": "0.5.1",
+				"@next/env": "13.5.2",
+				"@next/swc-darwin-arm64": "13.5.2",
+				"@next/swc-darwin-x64": "13.5.2",
+				"@next/swc-linux-arm64-gnu": "13.5.2",
+				"@next/swc-linux-arm64-musl": "13.5.2",
+				"@next/swc-linux-x64-gnu": "13.5.2",
+				"@next/swc-linux-x64-musl": "13.5.2",
+				"@next/swc-win32-arm64-msvc": "13.5.2",
+				"@next/swc-win32-ia32-msvc": "13.5.2",
+				"@next/swc-win32-x64-msvc": "13.5.2",
+				"@swc/helpers": "0.5.2",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001406",
 				"postcss": "8.4.14",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"imgix-url-builder": "^0.0.4"
 	},
 	"devDependencies": {
-		"@prismicio/client": "^7.1.0",
+		"@prismicio/client": "^7.2.0",
 		"@prismicio/mock": "^0.3.0",
 		"@size-limit/preset-small-lib": "^8.2.4",
 		"@types/react-test-renderer": "^18.0.0",
@@ -71,7 +71,7 @@
 		"eslint-plugin-tsdoc": "^0.2.17",
 		"happy-dom": "^9.20.3",
 		"memfs": "^3.5.3",
-		"next": "^13.4.5-canary.9",
+		"next": "^13.5.2",
 		"node-fetch": "^3.3.1",
 		"prettier": "^2.8.8",
 		"prettier-plugin-jsdoc": "^0.4.2",

--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -3,9 +3,16 @@ import { draftMode } from "next/headers";
 import { NextApiRequestLike, NextApiResponseLike } from "./types";
 
 /**
- * Configuration for `exitPreview`.
+ * @deprecated Use `ExitPreviewAPIRouteConfig` instead when `exitPreview()` is
+ *   used in a Pages Router API endpoint. `exitPreview()` does not require any
+ *   configuration when used in an App Router Route Handler.
  */
-export type ExitPreviewConfig = {
+export type ExitPreviewConfig = ExitPreviewAPIRouteConfig;
+
+/**
+ * Configuration for `exitPreview()` when used in a Pages Router API route.
+ */
+export type ExitPreviewAPIRouteConfig = {
 	/**
 	 * **Only use this parameter in the Pages Directory (/pages).**
 	 *
@@ -27,21 +34,18 @@ export type ExitPreviewConfig = {
 
 /**
  * Ends a Prismic preview session within a Next.js app. This function should be
- * used in a Router Handler or an API Route, depending on which you are using
+ * used in a Router Handler or an API route, depending on whether you are using
  * the App Router or Pages Router.
- *
- * `exitPreview()` assumes Draft Mode is being used unless a Pages Router API
- * Route `res` object is provided to the function.
  *
  * @example Usage within an App Router Route Handler.
  *
  * ```typescript
- * // src/app/exit-preview/route.js
+ * // src/app/api/exit-preview/route.js
  *
  * import { exitPreview } from "@prismicio/next";
  *
- * export async function GET() {
- * 	await exitPreview();
+ * export function GET() {
+ * 	return exitPreview();
  * }
  * ```
  *
@@ -52,12 +56,16 @@ export type ExitPreviewConfig = {
  *
  * import { exitPreview } from "@prismicio/next";
  *
- * export default async function handler(req, res) {
- * 	await exitPreview({ req, res });
+ * export default function handler(req, res) {
+ * 	exitPreview({ req, res });
  * }
  * ```
  */
-export function exitPreview(config?: ExitPreviewConfig): Response | void {
+export function exitPreview(): Response;
+export function exitPreview(config: ExitPreviewAPIRouteConfig): void;
+export function exitPreview(
+	config?: ExitPreviewAPIRouteConfig,
+): Response | void {
 	if (config?.res) {
 		// Assume Preview Mode is being used.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@ export { setPreviewData } from "./setPreviewData";
 export type { SetPreviewDataConfig } from "./setPreviewData";
 
 export { exitPreview } from "./exitPreview";
-export type { ExitPreviewConfig } from "./exitPreview";
+export type {
+	ExitPreviewConfig,
+	ExitPreviewAPIRouteConfig,
+} from "./exitPreview";
 
 export { PrismicPreview } from "./PrismicPreview";
 export type { PrismicPreviewProps } from "./PrismicPreview";
@@ -14,7 +17,11 @@ export { enableAutoPreviews } from "./enableAutoPreviews";
 export type { EnableAutoPreviewsConfig } from "./enableAutoPreviews";
 
 export { redirectToPreviewURL } from "./redirectToPreviewURL";
-export type { RedirectToPreviewURLConfig } from "./redirectToPreviewURL";
+export type {
+	RedirectToPreviewURLConfig,
+	RedirectToPreviewURLRouteHandlerConfig,
+	RedirectToPreviewURLAPIEndpointConfig,
+} from "./redirectToPreviewURL";
 
 export { PrismicNextImage } from "./PrismicNextImage";
 export type { PrismicNextImageProps } from "./PrismicNextImage";

--- a/src/redirectToPreviewURL.ts
+++ b/src/redirectToPreviewURL.ts
@@ -8,34 +8,7 @@ import {
 	NextRequestLike,
 } from "./types";
 
-/**
- * Preview config for enabling previews with redirectToPreviewURL
- */
-export type RedirectToPreviewURLConfig = (
-	| {
-			/**
-			 * The `request` object from a Next.js Route Handler.
-			 *
-			 * @see Next.js Route Handler docs: \<https://beta.nextjs.org/docs/routing/route-handlers\>
-			 */
-			request: NextRequestLike;
-	  }
-	| {
-			/**
-			 * The `req` object from a Next.js API route.
-			 *
-			 * @see Next.js API route docs: \<https://nextjs.org/docs/api-routes/introduction\>
-			 */
-			req: NextApiRequestLike;
-
-			/**
-			 * The `res` object from a Next.js API route.
-			 *
-			 * @see Next.js API route docs: \<https://nextjs.org/docs/api-routes/introduction\>
-			 */
-			res: NextApiResponseLike;
-	  }
-) & {
+type RedirectToPreviewURLConfigBase = {
 	/**
 	 * The Prismic client configured for the preview session's repository.
 	 */
@@ -75,13 +48,46 @@ export type RedirectToPreviewURLConfig = (
 	basePath?: string;
 };
 
-/**
- * Redirects a visitor to the URL of a previewed Prismic document from within a
- * Next.js Route Handler or API route.
- */
+export type RedirectToPreviewURLRouteHandlerConfig =
+	RedirectToPreviewURLConfigBase & {
+		/**
+		 * The `request` object from a Next.js Route Handler.
+		 *
+		 * @see Next.js Route Handler docs: \<https://nextjs.org/docs/app/building-your-application/routing/route-handlers\>
+		 */
+		request: NextRequestLike;
+	};
+
+export type RedirectToPreviewURLAPIEndpointConfig =
+	RedirectToPreviewURLConfigBase & {
+		/**
+		 * The `req` object from a Next.js API route.
+		 *
+		 * @see Next.js API route docs: \<https://nextjs.org/docs/pages/building-your-application/routing/api-routes\>
+		 */
+		req: NextApiRequestLike;
+
+		/**
+		 * The `res` object from a Next.js API route.
+		 *
+		 * @see Next.js API route docs: \<https://nextjs.org/docs/pages/building-your-application/routing/api-routes\>
+		 */
+		res: NextApiResponseLike;
+	};
+
+export type RedirectToPreviewURLConfig =
+	| RedirectToPreviewURLRouteHandlerConfig
+	| RedirectToPreviewURLAPIEndpointConfig;
+
+export async function redirectToPreviewURL(
+	config: RedirectToPreviewURLRouteHandlerConfig,
+): Promise<never>;
+export async function redirectToPreviewURL(
+	config: RedirectToPreviewURLAPIEndpointConfig,
+): Promise<void>;
 export async function redirectToPreviewURL(
 	config: RedirectToPreviewURLConfig,
-): Promise<void> {
+): Promise<never | void> {
 	const basePath = config.basePath || "";
 	const request = "request" in config ? config.request : config.req;
 

--- a/test/redirectToPreviewURL.test.ts
+++ b/test/redirectToPreviewURL.test.ts
@@ -433,8 +433,7 @@ describe("Pages Router", () => {
 	});
 
 	it("throws if res is not provided", async () => {
-		// @ts-expect-error - We are purposely omitting `res` from the
-		// config.
+		// @ts-expect-error - We are purposely omitting `res` from the config.
 		const config: RedirectToPreviewURLConfig = {
 			client: prismic.createClient("qwerty", { fetch: vi.fn() }),
 			req: {
@@ -451,7 +450,10 @@ describe("Pages Router", () => {
 		);
 
 		expect(async () => {
-			await redirectToPreviewURL(config);
+			await redirectToPreviewURL(
+				// @ts-expect-error - We are purposely omitting `res` from the config.
+				config,
+			);
 		}).rejects.toThrow(/the `res` object from the api route must be provided/i);
 	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a TypeScript error thrown when running `next build` in TypeScript projects. The error comes from `redirectToPreviewURL()` and `exitPreview()`'s return types.

The error only happens in projects using Next.js >13.5.1; the return type of Route Handlers changed to require a `Response` return value.

Although the changes in this packages are technically non-breaking, project code must be updated as a result of Next.js' changes.

Fixes #84

### How to fix your project

1. Update to the latest version of `@prismicio/next`:

   ```sh
   npm install @prismicio/next@latest
   ```

2. Add `return` to `app/api/preview/route.ts` (or wherever you are using `redirectToPreviewURL()`):

   ```diff
    // app/api/preview/route.ts

    export async function GET(request: NextRequest) {
      const client = createClient();

   -  await redirectToPreviewURL({ client, request });
   +  return await redirectToPreviewURL({ client, request });
    }
   ```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦩
