### PR TITLE
fix: support shared previews when the preview cookie does not contain `_tracker`

### DIFF
--- a/src/lib/getPreviewCookieRepositoryName.ts
+++ b/src/lib/getPreviewCookieRepositoryName.ts
@@ -9,6 +9,6 @@
 export const getPreviewCookieRepositoryName = (
 	previewCookie: string,
 ): string | undefined => {
-	return (decodeURIComponent(previewCookie).match(/,"(.+).prismic.io"/) ||
+	return (decodeURIComponent(previewCookie).match(/"([^"]+)\.prismic\.io"/) ||
 		[])[1];
 };

--- a/test/PrismicPreview.test.tsx
+++ b/test/PrismicPreview.test.tsx
@@ -365,6 +365,34 @@ test("supports shared links", async () => {
 	renderer.act(() => unmount());
 });
 
+test("supports shared links when `_tracker` is not in the preview cookie", async () => {
+	const replace = vi.fn() as NextRouter["replace"];
+
+	vi.mocked(useRouter).mockImplementation(() => {
+		return {
+			isPreview: false,
+			basePath: "",
+			asPath: mockPagePath,
+			replace,
+		} as NextRouter;
+	});
+
+	globalThis.document.cookie = `io.prismic.preview=${JSON.stringify({
+		"qwerty.prismic.io": {},
+	})}`;
+
+	const { unmount } = render(<PrismicPreview repositoryName="qwerty" />);
+
+	await tick();
+
+	expect(fetch).toHaveBeenCalledWith("/api/preview");
+	expect(replace).toHaveBeenCalledWith(mockPagePath, undefined, {
+		scroll: false,
+	});
+
+	renderer.act(() => unmount());
+});
+
 test("ignores invalid preview cookie", async () => {
 	const replace = vi.fn() as NextRouter["replace"];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where shared previews did not start when the Prismic preview cookie did not contain a `_tracker` property.

The preview cookie typically looks like this:

```json
{
  "_tracker": "abc123",
  "example-prismic-repo.prismic.io": {
    "preview": "https://example-prismic-repo.prismic.io/previews/abc:123?websitePreviewId=xyz"
  }
}
```

However, the `_tracker` property is not guaranteed to exist.

Before this PR, `<PrismicPreview>` relied on `_tracker` existing to detect the cookie's Prismic repository name.

After this PR, `<PrismicPreview>` supports both cases.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
