### PR TITLE
feat: add `createLocaleRedirect()` to simplify i18n routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
 			"version": "1.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"imgix-url-builder": "^0.0.4"
+				"@formatjs/intl-localematcher": "^0.5.2",
+				"imgix-url-builder": "^0.0.4",
+				"negotiator": "^0.6.3"
 			},
 			"devDependencies": {
 				"@prismicio/client": "^7.2.0",
 				"@prismicio/mock": "^0.3.1",
 				"@size-limit/preset-small-lib": "^9.0.0",
+				"@types/negotiator": "^0.6.3",
 				"@types/react-test-renderer": "^18.0.2",
 				"@typescript-eslint/eslint-plugin": "^6.7.2",
 				"@typescript-eslint/parser": "^6.7.2",
@@ -860,6 +863,14 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@formatjs/intl-localematcher": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.2.tgz",
+			"integrity": "sha512-txaaE2fiBMagLrR4jYhxzFO6wEdEG4TPMqrzBAcbr4HFUYzH/YC+lg6OIzKCHm8WgDdyQevxbAAV1OgcXctuGw==",
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.11",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -1442,6 +1453,12 @@
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+			"dev": true
+		},
+		"node_modules/@types/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@types/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-JkXTOdKs5MF086b/pt8C3+yVp3iDUwG635L7oCH6HvJvvr6lSUU5oe/gLXnPEfYRROHjJIPgCV6cuAg8gGkntQ==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -6372,6 +6389,14 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -8322,8 +8347,7 @@
 		"node_modules/tslib": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-			"dev": true
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -52,12 +52,15 @@
 		"test": "npm run lint && npm run types && npm run unit && npm run build && npm run size"
 	},
 	"dependencies": {
-		"imgix-url-builder": "^0.0.4"
+		"@formatjs/intl-localematcher": "^0.5.2",
+		"imgix-url-builder": "^0.0.4",
+		"negotiator": "^0.6.3"
 	},
 	"devDependencies": {
 		"@prismicio/client": "^7.2.0",
 		"@prismicio/mock": "^0.3.1",
 		"@size-limit/preset-small-lib": "^9.0.0",
+		"@types/negotiator": "^0.6.3",
 		"@types/react-test-renderer": "^18.0.2",
 		"@typescript-eslint/eslint-plugin": "^6.7.2",
 		"@typescript-eslint/parser": "^6.7.2",

--- a/src/createLocaleRedirect.ts
+++ b/src/createLocaleRedirect.ts
@@ -1,0 +1,60 @@
+import Negotiator from "negotiator";
+import { match } from "@formatjs/intl-localematcher";
+import * as prismic from "@prismicio/client";
+
+import { NextRequestLike } from "./types";
+
+export type CreateLocaleRedirectConfig = {
+	request: NextRequestLike;
+	client: Pick<prismic.Client, "getRepository">;
+	localeOverrides?: Record<string, string>;
+	omitDefaultLocale?: boolean;
+};
+
+/**
+ * Creates a `Response` that redirects a request to the requester's preferred
+ * locale. This function returns `undefined` if the request already contains a
+ * locale.
+ *
+ * @returns A `Response` if the request should be redirected, `undefined`
+ *   otherwise.
+ */
+export const createLocaleRedirect = async (
+	config: CreateLocaleRedirectConfig,
+): Promise<Response | undefined> => {
+	const repository = await config.client.getRepository();
+
+	const locales = repository.languages.map((language) => {
+		return config.localeOverrides?.[language.id] ?? language.id;
+	});
+	const defaultLocale = locales[0];
+
+	const { pathname } = config.request.nextUrl;
+	const pathnameHasLocale = locales.some(
+		(locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
+	);
+
+	if (pathnameHasLocale) {
+		return;
+	}
+
+	let locale = defaultLocale;
+
+	const headers = {
+		"accept-language":
+			config.request.headers.get("accept-language") ?? undefined,
+	};
+
+	if (headers["accept-language"]) {
+		const languages = new Negotiator({ headers }).languages();
+		locale = match(languages, locales, defaultLocale);
+	}
+
+	if (locale === defaultLocale && config.omitDefaultLocale) {
+		return;
+	}
+
+	config.request.nextUrl.pathname = `/${locale}${pathname}`;
+
+	return Response.redirect(config.request.nextUrl as URL);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,9 @@ export type {
 	RedirectToPreviewURLAPIEndpointConfig,
 } from "./redirectToPreviewURL";
 
+export { createLocaleRedirect } from "./createLocaleRedirect";
+export type { CreateLocaleRedirectConfig } from "./createLocaleRedirect";
+
 export { PrismicNextImage } from "./PrismicNextImage";
 export type { PrismicNextImageProps } from "./PrismicNextImage";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,10 +46,11 @@ export type CreateClientConfig = ClientConfig & {
  */
 export type NextRequestLike = {
 	headers: {
-		get(name: string): string | null;
+		get(name: string): string | string[] | null;
 	};
 	url: string;
 	nextUrl: {
+		pathname: string;
 		searchParams: {
 			get(name: string): string | null;
 		};

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type CreateClientConfig = ClientConfig & {
  */
 export type NextRequestLike = {
 	headers: {
-		get(name: string): string | string[] | null;
+		get(name: string): string | null;
 	};
 	url: string;
 	nextUrl: {

--- a/test/createLocaleRedirect.test.ts
+++ b/test/createLocaleRedirect.test.ts
@@ -1,0 +1,185 @@
+import { vi, it, expect } from "vitest";
+import * as prismic from "@prismicio/client";
+
+import { CreateLocaleRedirectConfig, createLocaleRedirect } from "../src";
+
+type CreateRequestArgs = {
+	url: string;
+	acceptLanguage: string | null;
+};
+const createRequest = (
+	args: CreateRequestArgs,
+): CreateLocaleRedirectConfig["request"] => {
+	const url = new URL(args.url);
+
+	return {
+		url: url.toString(),
+		nextUrl: url,
+		headers: {
+			get: vi.fn((name) =>
+				name.toLowerCase() === "accept-language" ? args.acceptLanguage : null,
+			),
+		},
+	};
+};
+
+type MockGetRepositoryArgs = {
+	client: prismic.Client;
+} & Partial<prismic.Repository>;
+
+const mockGetRepository = ({
+	client,
+	...repository
+}: MockGetRepositoryArgs) => {
+	vi.spyOn(client, "getRepository").mockImplementation(
+		async () => repository as prismic.Repository,
+	);
+};
+
+it("creates a redirect with the request's preferred locale", async () => {
+	const client = prismic.createClient("qwerty", { fetch: vi.fn() });
+
+	const config: CreateLocaleRedirectConfig = {
+		client,
+		request: createRequest({
+			url: "https://example.com/foo",
+			acceptLanguage: "fr-fr,fr;q=0.5",
+		}),
+	};
+
+	mockGetRepository({
+		client,
+		languages: [{ id: "fr-fr", name: "French (France)" }],
+	});
+
+	const redirect = await createLocaleRedirect(config);
+
+	expect(redirect?.headers.get("location")).toBe(
+		"https://example.com/fr-fr/foo",
+	);
+	expect(redirect?.status).toBe(302);
+});
+
+it("returns undefined if the request already contains a locale", async () => {
+	const client = prismic.createClient("qwerty", { fetch: vi.fn() });
+
+	const config: CreateLocaleRedirectConfig = {
+		client,
+		request: createRequest({
+			url: "https://example.com/en-us/foo",
+			acceptLanguage: "fr-fr,fr;q=0.5",
+		}),
+	};
+
+	mockGetRepository({
+		client,
+		languages: [
+			{ id: "fr-fr", name: "French (France)" },
+			{ id: "en-us", name: "English (US)" },
+		],
+	});
+
+	const redirect = await createLocaleRedirect(config);
+
+	expect(redirect).toBe(undefined);
+});
+
+it("uses the default locale if the request's preferred language is unavailable", async () => {
+	const client = prismic.createClient("qwerty", { fetch: vi.fn() });
+
+	const config: CreateLocaleRedirectConfig = {
+		client,
+		request: createRequest({
+			url: "https://example.com/foo",
+			acceptLanguage: "fr-fr,fr;q=0.5",
+		}),
+	};
+
+	mockGetRepository({
+		client,
+		languages: [
+			{ id: "en-us", name: "English (US)" },
+			{ id: "en-uk", name: "English (UK)" },
+		],
+	});
+
+	const redirect = await createLocaleRedirect(config);
+
+	expect(redirect?.headers.get("location")).toBe(
+		"https://example.com/en-us/foo",
+	);
+	expect(redirect?.status).toBe(302);
+});
+
+it("allows for custom locale codes", async () => {
+	const client = prismic.createClient("qwerty", { fetch: vi.fn() });
+
+	const config: CreateLocaleRedirectConfig = {
+		client,
+		request: createRequest({
+			url: "https://example.com/foo",
+			acceptLanguage: "fr-fr,fr;q=0.5",
+		}),
+		localeOverrides: {
+			"fr-fr": "custom-locale",
+		},
+	};
+
+	mockGetRepository({
+		client,
+		languages: [{ id: "fr-fr", name: "French (France)" }],
+	});
+
+	const redirect = await createLocaleRedirect(config);
+
+	expect(redirect?.headers.get("location")).toBe(
+		"https://example.com/custom-locale/foo",
+	);
+	expect(redirect?.status).toBe(302);
+});
+
+it("returns undefined when omitDefaultLocale is true and the preferred locale is the default locale", async () => {
+	const client = prismic.createClient("qwerty", { fetch: vi.fn() });
+
+	const config: CreateLocaleRedirectConfig = {
+		client,
+		request: createRequest({
+			url: "https://example.com/foo",
+			acceptLanguage: "fr-fr,fr;q=0.5",
+		}),
+		omitDefaultLocale: true,
+	};
+
+	mockGetRepository({
+		client,
+		languages: [{ id: "fr-fr", name: "French (France)" }],
+	});
+
+	const redirect = await createLocaleRedirect(config);
+
+	expect(redirect).toBe(undefined);
+});
+
+it("uses the default locale when the accept-language header is not set", async () => {
+	const client = prismic.createClient("qwerty", { fetch: vi.fn() });
+
+	const config: CreateLocaleRedirectConfig = {
+		client,
+		request: createRequest({
+			url: "https://example.com/foo",
+			acceptLanguage: null,
+		}),
+	};
+
+	mockGetRepository({
+		client,
+		languages: [{ id: "fr-fr", name: "French (France)" }],
+	});
+
+	const redirect = await createLocaleRedirect(config);
+
+	expect(redirect?.headers.get("location")).toBe(
+		"https://example.com/fr-fr/foo",
+	);
+	expect(redirect?.status).toBe(302);
+});

--- a/test/redirectToPreviewURL.test.ts
+++ b/test/redirectToPreviewURL.test.ts
@@ -46,6 +46,7 @@ describe("App Router", () => {
 			request: {
 				url: "/foo",
 				nextUrl: {
+					pathname: "/foo",
 					searchParams: {
 						get() {
 							return null;
@@ -73,6 +74,7 @@ describe("App Router", () => {
 			request: {
 				url: "/foo",
 				nextUrl: {
+					pathname: "/foo",
 					searchParams: {
 						get() {
 							return null;
@@ -101,6 +103,7 @@ describe("App Router", () => {
 			request: {
 				url: `/foo`,
 				nextUrl: {
+					pathname: "/foo",
 					searchParams: {
 						get() {
 							return null;
@@ -130,6 +133,7 @@ describe("App Router", () => {
 			request: {
 				url: `/foo?token=${token}`,
 				nextUrl: {
+					pathname: "/foo",
 					searchParams: {
 						get(name) {
 							if (name === "token") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds `createLocaleRedirect()`. The function should be used in a `middleware.js` file to automatically handle internationalizated routes.

```ts
// middleware.js

import { createClient } from "@/prismicio";
import { createLocaleRedirect } from "@prismicio/next";

export async function middleware(request) {
  const client = createClient();
  const redirect = await createLocaleRedirect({ client, request });

  if (redirect) {
    return redirect;
  }
}

export const config = {
  // Do not localize these paths.
  matcher: ["/((?!_next|api|slice-simulator|favicon.ico).*)"],
};
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🫏
