### PR TITLE
fix: use React 18 and 19 compatible types

### DIFF
--- a/src/PrismicNextImage.tsx
+++ b/src/PrismicNextImage.tsx
@@ -85,7 +85,7 @@ export const PrismicNextImage = ({
 	height,
 	fallback = null,
 	...restProps
-}: PrismicNextImageProps): JSX.Element => {
+}: PrismicNextImageProps): React.JSX.Element => {
 	if (process.env.NODE_ENV !== "production") {
 		if (typeof alt === "string" && alt !== "") {
 			console.warn(

--- a/src/PrismicNextLink.tsx
+++ b/src/PrismicNextLink.tsx
@@ -31,7 +31,7 @@ export type PrismicNextLinkProps = Omit<
 export const PrismicNextLink = React.forwardRef<
 	HTMLAnchorElement,
 	PrismicNextLinkProps
->(function PrismicNextLink(props, ref): JSX.Element | null {
+>(function PrismicNextLink(props, ref): React.JSX.Element | null {
 	const { field, document, linkResolver, children, ...restProps } = props;
 	const {
 		href: computedHref,

--- a/src/PrismicPreview.tsx
+++ b/src/PrismicPreview.tsx
@@ -51,7 +51,7 @@ export function PrismicPreview({
 	repositoryName,
 	children,
 	...props
-}: PrismicPreviewProps): JSX.Element | Promise<JSX.Element> {
+}: PrismicPreviewProps): React.JSX.Element | Promise<React.JSX.Element> {
 	const toolbarSrc = prismic.getToolbarSrc(repositoryName);
 	let isDraftMode = false;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR updates `@prismicio/next` to be compatible with React 18 and 19 TypeScript types.

React 19 requires changing `JSX.Element` to `React.JSX.Element` ([see the React 19 release notes](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript)). The change is compatible with React 18's TypeScript types.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
