### PR TITLE
fix: restore ESM exports so the entry tree-shakes (#142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,15 +26,28 @@
 	"type": "module",
 	"sideEffects": false,
 	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.cjs"
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		},
 		"./pages": {
-			"types": "./dist/pages.d.ts",
-			"default": "./dist/pages.cjs"
+			"import": {
+				"types": "./dist/pages.d.ts",
+				"default": "./dist/pages.js"
+			},
+			"require": {
+				"types": "./dist/pages.d.cts",
+				"default": "./dist/pages.cjs"
+			}
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
### Summary

Importing a single helper such as `PrismicNextImage` currently pulls the preview client, slice simulator, and all of `@prismicio/client` into the browser bundle. Fixes #142.

### Root cause

#130 ("serve CJS runtime with ESM type declarations") removed the `import` (ESM) condition from the package `exports`, leaving only the CJS barrel:

```jsonc
".": {
  "types": "./dist/index.d.ts",
  "default": "./dist/index.cjs"   // CJS only
}
```

`dist/index.cjs` eagerly `require()`s every submodule at load, so bundlers can't shake anything out. `v2.2.1` was unaffected because it still shipped an `import` build.

The ESM output (`dist/index.js`) is **still produced** by tsdown (`format: ["esm", "cjs"]`); it was just no longer referenced from `exports`.

### Fix

Restore the `import` condition (and `module`) while keeping #130's ESM/CJS type-declaration split via per-condition `types`:

- `import`  → `dist/index.js`  + `dist/index.d.ts`
- `require` → `dist/index.cjs` + `dist/index.d.cts`

One-file change to `package.json`. No source or build-config changes.

### Verification

Bundling an entry that imports only `PrismicNextImage` (esbuild, `--platform=browser`, react/next external):

| | Bundle size | `WriteClient` / `SimulatorManager` / `lz-string` |
| --- | --- | --- |
| before (CJS entry) | 74,629 bytes | bundled |
| after (ESM entry) | 2,104 bytes | not bundled |

`npm run lint`, `npm run types`, and `npm run build` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to `exports`/`module` fields; behavior improves for ESM bundlers with no application logic touched.
> 
> **Overview**
> **Restores proper dual-package resolution** so ESM consumers resolve `dist/index.js` and `dist/pages.js` again instead of falling through to the CJS barrels.
> 
> `package.json` now adds `"module": "./dist/index.js"` and splits `"."` and `"./pages"` `exports` into **`import`** (`.js` + `.d.ts`) and **`require`** (`.cjs` + `.d.cts`) conditions, keeping the #130 type-declaration split for CJS vs ESM.
> 
> This fixes bundlers pulling the entire CJS entry (and preview/simulator/`@prismicio/client` side effects) when importing a single helper like `PrismicNextImage`; no source or build changes—only wiring consumers back to the ESM artifacts tsdown already emits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83dd10c1eaf7b1727b16976a23117a6055d51114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->