### PR TITLE
test: check that the built package loads and tree-shakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ The following setup is required to work on this project:
 - `@prismicio/next` uses [Playwright](https://playwright.dev/) to test its APIs.
 - Using Playwright allows us to test the package's components and helpers against real Next.js apps.
 - The package is tested against an App Router-based project and a Pages Router-based project.
+- The `build` Playwright project runs `next build` on each project and on a minimal Next 15 project. It checks that the published package loads and tree-shakes.
 
 ## :construction_worker: Develop
 

--- a/e2e-projects/next-15/.gitignore
+++ b/e2e-projects/next-15/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/.next/
+/out/
+next-env.d.ts

--- a/e2e-projects/next-15/.gitignore
+++ b/e2e-projects/next-15/.gitignore
@@ -1,4 +1,1 @@
-/node_modules
 /.next/
-/out/
-next-env.d.ts

--- a/e2e-projects/next-15/app/layout.jsx
+++ b/e2e-projects/next-15/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+	return (
+		<html lang="en">
+			<body>{children}</body>
+		</html>
+	)
+}

--- a/e2e-projects/next-15/app/page.jsx
+++ b/e2e-projects/next-15/app/page.jsx
@@ -1,12 +1,9 @@
 import { PrismicNextImage } from "@prismicio/next"
 
 const field = {
-	id: "example",
 	url: "https://images.prismic.io/example/photo.png?auto=format,compress",
 	alt: null,
-	copyright: null,
 	dimensions: { width: 800, height: 600 },
-	edit: { x: 0, y: 0, zoom: 1, background: "transparent" },
 }
 
 export default function Page() {

--- a/e2e-projects/next-15/app/page.jsx
+++ b/e2e-projects/next-15/app/page.jsx
@@ -1,0 +1,14 @@
+import { PrismicNextImage } from "@prismicio/next"
+
+const field = {
+	id: "example",
+	url: "https://images.prismic.io/example/photo.png?auto=format,compress",
+	alt: null,
+	copyright: null,
+	dimensions: { width: 800, height: 600 },
+	edit: { x: 0, y: 0, zoom: 1, background: "transparent" },
+}
+
+export default function Page() {
+	return <PrismicNextImage field={field} fallbackAlt="" />
+}

--- a/e2e-projects/next-15/next.config.mjs
+++ b/e2e-projects/next-15/next.config.mjs
@@ -1,0 +1,8 @@
+// Next 15 loads this file with Node's ESM loader. Importing the package here
+// checks that Node can load it (see #105 and #129).
+import "@prismicio/next"
+
+/** @type {import("next").NextConfig} */
+export default {
+	images: { remotePatterns: [{ hostname: "images.prismic.io" }] },
+}

--- a/e2e-projects/next-15/package.json
+++ b/e2e-projects/next-15/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "next-15",
+	"private": true,
+	"scripts": {
+		"build": "next build"
+	},
+	"dependencies": {
+		"@prismicio/client": "^7",
+		"next": "15",
+		"react": "19",
+		"react-dom": "19"
+	}
+}

--- a/e2e-projects/next-15/pages/PrismicNextLink.jsx
+++ b/e2e-projects/next-15/pages/PrismicNextLink.jsx
@@ -1,0 +1,5 @@
+import { PrismicNextLink } from "@prismicio/next/pages"
+
+export default function Page() {
+	return <PrismicNextLink href="/">Home</PrismicNextLink>
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,8 @@
       "license": "Apache-2.0",
       "workspaces": [
         ".",
-        "e2e-projects/app-router",
-        "e2e-projects/pages-router",
-        "e2e-projects/cache-components"
+        "e2e-projects/*",
+        "!e2e-projects/next-15"
       ],
       "dependencies": {
         "@prismicio/simulator": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "Apache-2.0",
       "workspaces": [
         ".",
-        "e2e-projects/*"
+        "e2e-projects/app-router",
+        "e2e-projects/pages-router",
+        "e2e-projects/cache-components"
       ],
       "dependencies": {
         "@prismicio/simulator": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
 	},
 	"workspaces": [
 		".",
-		"e2e-projects/app-router",
-		"e2e-projects/pages-router",
-		"e2e-projects/cache-components"
+		"e2e-projects/*",
+		"!e2e-projects/next-15"
 	],
 	"files": [
 		"dist",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
 	},
 	"workspaces": [
 		".",
-		"e2e-projects/*"
+		"e2e-projects/app-router",
+		"e2e-projects/pages-router",
+		"e2e-projects/cache-components"
 	],
 	"files": [
 		"dist",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert"
 import { existsSync, writeFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 
@@ -35,8 +34,13 @@ export default defineConfig({
 			},
 		},
 		{
+			name: "build",
+			testMatch: "build.spec.ts",
+			timeout: 5 * 60_000,
+		},
+		{
 			name: "app-router",
-			testIgnore: "cache-components.spec.ts",
+			testIgnore: ["cache-components.spec.ts", "build.spec.ts"],
 			dependencies: ["setup"],
 			use: {
 				...devices["Desktop Chrome"],
@@ -46,7 +50,7 @@ export default defineConfig({
 		},
 		{
 			name: "pages-router",
-			testIgnore: "cache-components.spec.ts",
+			testIgnore: ["cache-components.spec.ts", "build.spec.ts"],
 			dependencies: ["setup", "app-router"],
 			use: {
 				...devices["Desktop Chrome"],
@@ -102,6 +106,3 @@ declare global {
 		}
 	}
 }
-
-assert.ok(process.env.E2E_PRISMIC_EMAIL, "Missing E2E_PRISMIC_EMAIL env variable.")
-assert.ok(process.env.E2E_PRISMIC_PASSWORD, "Missing E2E_PRISMIC_PASSWORD env variable.")

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process"
-import { mkdtempSync, readFileSync, readdirSync } from "node:fs"
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -18,6 +18,12 @@ function run(file: string, args: string[], cwd: string): string {
 	return execFileSync(file, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] })
 }
 
+function build(project: string): void {
+	// The build cache treats `node_modules` as unchanged while the package version is the same.
+	rmSync(join(project, ".next/cache"), { recursive: true, force: true })
+	run("npx", ["next", "build"], project)
+}
+
 function clientJS(project: string): string {
 	const dir = join(project, ".next/static/chunks")
 	return readdirSync(dir, { recursive: true, encoding: "utf8" })
@@ -31,7 +37,7 @@ for (const name of ["app-router", "pages-router"]) {
 		const project = join(ROOT, "e2e-projects", name)
 
 		test("builds", () => {
-			run("npx", ["next", "build"], project)
+			build(project)
 		})
 
 		test("tree-shakes unused exports", () => {
@@ -56,7 +62,7 @@ test.describe.serial("next-15", () => {
 		)
 		const flags = ["--silent", "--no-save", "--no-package-lock", "--no-audit", "--no-fund"]
 		run("npm", ["install", ...flags, join(dir, tarball.trim())], project)
-		run("npx", ["next", "build"], project)
+		build(project)
 	})
 
 	test("tree-shakes unused exports", () => {

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -1,0 +1,67 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { expect, test } from "@playwright/test"
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url))
+
+/**
+ * Strings from code that no `@prismicio/next` export reaches (the Prismic Write API). When they
+ * appear in a client bundle, the package was not tree-shaken.
+ */
+const UNREACHABLE = ["https://asset-api.prismic.io", "https://migration.prismic.io"]
+
+function run(file: string, args: string[], cwd: string): string {
+	return execFileSync(file, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] })
+}
+
+function clientJS(project: string): string {
+	const dir = join(project, ".next/static/chunks")
+	return readdirSync(dir, { recursive: true, encoding: "utf8" })
+		.filter((file) => file.endsWith(".js"))
+		.map((file) => readFileSync(join(dir, file), "utf8"))
+		.join("\n")
+}
+
+for (const name of ["app-router", "pages-router"]) {
+	test.describe.serial(`${name} (Next 16)`, () => {
+		const project = join(ROOT, "e2e-projects", name)
+
+		test("builds", () => {
+			run("npx", ["next", "build"], project)
+		})
+
+		test("tree-shakes unused exports", () => {
+			test.fail(true, "https://github.com/prismicio/prismic-next/issues/142")
+			const js = clientJS(project)
+			for (const string of UNREACHABLE) expect(js).not.toContain(string)
+		})
+	})
+}
+
+test.describe.serial("next-15", () => {
+	const project = join(ROOT, "e2e-projects/next-15")
+
+	test("builds", () => {
+		// Install the package like a consumer. A workspace symlink would resolve `next/*` from the
+		// root `node_modules`, which is Next 16.
+		const dir = mkdtempSync(join(tmpdir(), "prismic-next-"))
+		const tarball = run(
+			"npm",
+			["pack", "--silent", "--ignore-scripts", "--pack-destination", dir],
+			ROOT,
+		)
+		const flags = ["--silent", "--no-save", "--no-package-lock", "--no-audit", "--no-fund"]
+		run("npm", ["install", ...flags, join(dir, tarball.trim())], project)
+		run("npx", ["next", "build"], project)
+	})
+
+	test("tree-shakes unused exports", () => {
+		test.fail(true, "https://github.com/prismicio/prismic-next/issues/142")
+		const js = clientJS(project)
+		for (const string of UNREACHABLE) expect(js).not.toContain(string)
+	})
+})

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -8,63 +8,40 @@ import { expect, test } from "@playwright/test"
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url))
 
-/**
- * Strings from code that no `@prismicio/next` export reaches (the Prismic Write API). When they
- * appear in a client bundle, the package was not tree-shaken.
- */
-const UNREACHABLE = ["https://asset-api.prismic.io", "https://migration.prismic.io"]
-
-function run(file: string, args: string[], cwd: string): string {
-	return execFileSync(file, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] })
+function run(file: string, args: string[], cwd: string) {
+	execFileSync(file, args, { cwd, stdio: ["ignore", "ignore", "inherit"] })
 }
 
-function build(project: string): void {
-	// The build cache treats `node_modules` as unchanged while the package version is the same.
-	rmSync(join(project, ".next/cache"), { recursive: true, force: true })
-	run("npx", ["next", "build"], project)
-}
-
-function clientJS(project: string): string {
-	const dir = join(project, ".next/static/chunks")
-	return readdirSync(dir, { recursive: true, encoding: "utf8" })
-		.filter((file) => file.endsWith(".js"))
-		.map((file) => readFileSync(join(dir, file), "utf8"))
-		.join("\n")
-}
-
-for (const name of ["app-router", "pages-router"]) {
-	test.describe.serial(`${name} (Next 16)`, () => {
+for (const name of ["app-router", "pages-router", "next-15"]) {
+	test.describe.serial(name, () => {
 		const project = join(ROOT, "e2e-projects", name)
 
 		test("builds", () => {
-			build(project)
+			if (name === "next-15") {
+				// Install the package like a consumer. A workspace symlink would resolve `next/*` from
+				// the root `node_modules`, which is Next 16.
+				const dir = mkdtempSync(join(tmpdir(), "prismic-next-"))
+				run("npm", ["pack", "--silent", "--ignore-scripts", "--pack-destination", dir], ROOT)
+				const [tarball] = readdirSync(dir)
+				const flags = ["--silent", "--no-save", "--no-package-lock", "--no-audit", "--no-fund"]
+				run("npm", ["install", ...flags, join(dir, tarball)], project)
+			}
+			// The build cache treats `node_modules` as unchanged while the package version is the same.
+			rmSync(join(project, ".next/cache"), { recursive: true, force: true })
+			run("npx", ["next", "build"], project)
 		})
 
 		test("tree-shakes unused exports", () => {
 			test.fail(true, "https://github.com/prismicio/prismic-next/issues/142")
-			const js = clientJS(project)
-			for (const string of UNREACHABLE) expect(js).not.toContain(string)
+			const dir = join(project, ".next/static/chunks")
+			const js = readdirSync(dir, { recursive: true, encoding: "utf8" })
+				.filter((file) => file.endsWith(".js"))
+				.map((file) => readFileSync(join(dir, file), "utf8"))
+				.join("\n")
+			// No `@prismicio/next` export reaches the Prismic Write API. Its URLs appear only when
+			// the package was not tree-shaken.
+			expect(js).not.toContain("https://asset-api.prismic.io")
+			expect(js).not.toContain("https://migration.prismic.io")
 		})
 	})
 }
-
-test.describe.serial("next-15", () => {
-	const project = join(ROOT, "e2e-projects/next-15")
-
-	test("builds", () => {
-		// Install the package like a consumer. A workspace symlink would resolve `next/*` from the
-		// root `node_modules`, which is Next 16.
-		const dir = mkdtempSync(join(tmpdir(), "prismic-next-"))
-		run("npm", ["pack", "--silent", "--ignore-scripts", "--pack-destination", dir], ROOT)
-		const [tarball] = readdirSync(dir)
-		const flags = ["--silent", "--no-save", "--no-package-lock", "--no-audit", "--no-fund"]
-		run("npm", ["install", ...flags, join(dir, tarball)], project)
-		build(project)
-	})
-
-	test("tree-shakes unused exports", () => {
-		test.fail(true, "https://github.com/prismicio/prismic-next/issues/142")
-		const js = clientJS(project)
-		for (const string of UNREACHABLE) expect(js).not.toContain(string)
-	})
-})

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -55,13 +55,10 @@ test.describe.serial("next-15", () => {
 		// Install the package like a consumer. A workspace symlink would resolve `next/*` from the
 		// root `node_modules`, which is Next 16.
 		const dir = mkdtempSync(join(tmpdir(), "prismic-next-"))
-		const tarball = run(
-			"npm",
-			["pack", "--silent", "--ignore-scripts", "--pack-destination", dir],
-			ROOT,
-		)
+		run("npm", ["pack", "--silent", "--ignore-scripts", "--pack-destination", dir], ROOT)
+		const [tarball] = readdirSync(dir)
 		const flags = ["--silent", "--no-save", "--no-package-lock", "--no-audit", "--no-fund"]
-		run("npm", ["install", ...flags, join(dir, tarball.trim())], project)
+		run("npm", ["install", ...flags, join(dir, tarball)], project)
 		build(project)
 	})
 

--- a/tests/infra/test.ts
+++ b/tests/infra/test.ts
@@ -22,6 +22,8 @@ const PREVIEW_TOOLBAR_TIMEOUT = 30_000
 
 export const test = base.extend<Fixtures>({
 	prismic: async ({ page }, use) => {
+		assert(process.env.E2E_PRISMIC_EMAIL, "Missing E2E_PRISMIC_EMAIL env variable.")
+		assert(process.env.E2E_PRISMIC_PASSWORD, "Missing E2E_PRISMIC_PASSWORD env variable.")
 		const prismic = new Prismic({
 			baseURL: "https://prismic.io",
 			auth: {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves:

### Description

This PR adds a `build` Playwright project. It runs `next build` on the App Router project, the Pages Router project, and a new minimal Next 15 project. The tests make sure that the package loads without errors and that unused exports are tree-shaken.

The Next 15 project imports the package from `next.config.mjs`. Next 15 loads that file with Node's ESM loader. This is the path that caused #105 and #129. Next 16 does not use this path.

The Next 15 project installs the package from an `npm pack` tarball, not from a workspace symlink. A symlink resolves `next/*` from the root `node_modules`, which is Next 16.

The tree-shaking tests are marked with `test.fail()` because of #142. They fail on `main` today. The fix PR will remove the annotation.

Expected results:

| Branch | Next 15 builds | Next 16 builds | Tree-shakes |
| --- | --- | --- | --- |
| `main` | ✅ Pass | ✅ Pass | ❌ Fails (expected, #142) |
| #143 | ❌ Fails (`next/navigation` is not found) | ✅ Pass | ✅ Pass |
| #145 | ✅ Pass | ✅ Pass | ✅ Pass |

```sh
npx playwright test --project build --reporter=list

  ✓  app-router (Next 16) › builds
  ✘  app-router (Next 16) › tree-shakes unused exports   # expected failure
  ✓  pages-router (Next 16) › builds
  ✘  pages-router (Next 16) › tree-shakes unused exports # expected failure
  ✓  next-15 › builds
  ✘  next-15 › tree-shakes unused exports                # expected failure
  6 passed
```

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

1. Run `npm ci`.
2. Run `npx playwright test --project build`.
3. Make sure that the three `builds` tests pass and the three `tree-shakes` tests are reported as expected failures.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/e2e coverage and contributor docs; no production package runtime behavior is modified.
> 
> **Overview**
> Adds a dedicated Playwright **`build`** project that runs **`next build`** against the existing App Router and Pages Router e2e apps, plus a new minimal **Next 15** fixture.
> 
> The Next 15 app is **excluded from npm workspaces** so the build test can **`npm pack`** and install `@prismicio/next` like a real consumer (avoiding Next 16 from the root `node_modules`). Its **`next.config.mjs`** imports the package to cover the Node ESM load path from #105 / #129.
> 
> Each fixture gets a **build** test and a **tree-shake** check (client bundles must not include Prismic Write API URLs); tree-shake cases are **`test.fail()`** until #142 is fixed. **Prismic E2E credential asserts** move from `playwright.config.ts` into the shared test fixture so the build project can run without `.env.test.local`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0044aa0d5047f4eac9c6f4dff688cbf5889a2467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->