### PR TITLE
fix: restore ESM exports and make the ESM build loadable by Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,24 +30,12 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"import": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			},
-			"require": {
-				"types": "./dist/index.d.cts",
-				"default": "./dist/index.cjs"
-			}
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
 		},
 		"./pages": {
-			"import": {
-				"types": "./dist/pages.d.ts",
-				"default": "./dist/pages.js"
-			},
-			"require": {
-				"types": "./dist/pages.d.cts",
-				"default": "./dist/pages.cjs"
-			}
+			"import": "./dist/pages.js",
+			"require": "./dist/pages.cjs"
 		},
 		"./package.json": "./package.json"
 	},

--- a/package.json
+++ b/package.json
@@ -30,12 +30,24 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.cjs"
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		},
 		"./pages": {
-			"types": "./dist/pages.d.ts",
-			"default": "./dist/pages.cjs"
+			"import": {
+				"types": "./dist/pages.d.ts",
+				"default": "./dist/pages.js"
+			},
+			"require": {
+				"types": "./dist/pages.d.cts",
+				"default": "./dist/pages.cjs"
+			}
 		},
 		"./package.json": "./package.json"
 	},

--- a/src/SliceSimulator.tsx
+++ b/src/SliceSimulator.tsx
@@ -2,7 +2,7 @@
 
 import { SimulatorManager, StateEventType, getDefaultMessage } from "@prismicio/simulator/kit"
 import type { SliceSimulatorProps as BaseSliceSimulatorProps } from "@prismicio/simulator/kit"
-import { compressToEncodedURIComponent } from "lz-string"
+import lzString from "lz-string"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import type { FC, ReactNode } from "react"
@@ -52,7 +52,7 @@ export const SliceSimulator: FC<SliceSimulatorProps> = ({
 				const url = new URL(window.location.href)
 				url.searchParams.set(
 					STATE_PARAMS_KEY,
-					compressToEncodedURIComponent(JSON.stringify(newSlices)),
+					lzString.compressToEncodedURIComponent(JSON.stringify(newSlices)),
 				)
 
 				window.history.replaceState(null, "", url)

--- a/src/cacheTagPrismicPages.ts
+++ b/src/cacheTagPrismicPages.ts
@@ -1,5 +1,7 @@
 import type { PrismicDocument } from "@prismicio/client"
-import { cacheTag } from "next/cache"
+// A namespace import keeps Node.js from failing to load the ESM build on
+// Next.js 15, where `cacheTag` does not exist yet.
+import * as nextCache from "next/cache"
 
 import { getPrismicCacheTags } from "./getPrismicCacheTags"
 
@@ -16,5 +18,5 @@ import { getPrismicCacheTags } from "./getPrismicCacheTags"
  * @see {@link https://nextjs.org/docs/app/api-reference/functions/cacheTag}
  */
 export function cacheTagPrismicPages(pages: PrismicDocument[]): void {
-	cacheTag(...getPrismicCacheTags(pages))
+	nextCache.cacheTag(...getPrismicCacheTags(pages))
 }

--- a/src/cacheTagPrismicPages.ts
+++ b/src/cacheTagPrismicPages.ts
@@ -1,6 +1,5 @@
 import type { PrismicDocument } from "@prismicio/client"
-// A namespace import keeps Node.js from failing to load the ESM build on
-// Next.js 15, where `cacheTag` does not exist yet.
+// Namespace import: Next.js 15 has no `cacheTag`, and a named import would fail to link.
 import * as nextCache from "next/cache"
 
 import { getPrismicCacheTags } from "./getPrismicCacheTags"

--- a/src/getSlices.ts
+++ b/src/getSlices.ts
@@ -1,7 +1,7 @@
 import { getDefaultSlices } from "@prismicio/simulator/kit"
 import type { StateEvents, StateEventType } from "@prismicio/simulator/kit"
-import { decompressFromEncodedURIComponent } from "lz-string"
+import lzString from "lz-string"
 
 export const getSlices = (state: string | null | undefined): StateEvents[StateEventType.Slices] => {
-	return state ? JSON.parse(decompressFromEncodedURIComponent(state)) : getDefaultSlices()
+	return state ? JSON.parse(lzString.decompressFromEncodedURIComponent(state)) : getDefaultSlices()
 }

--- a/src/redirectToPreviewURL.ts
+++ b/src/redirectToPreviewURL.ts
@@ -1,5 +1,4 @@
 import { cookie as prismicCookie, type Client, type LinkResolverFunction } from "@prismicio/client"
-import { redirect } from "next/navigation"
 
 import type { NextRequestLike } from "./types"
 
@@ -41,6 +40,11 @@ export async function redirectToPreviewURL(config: RedirectToPreviewURLConfig): 
 	// in a Server Component which is not supported in the pages/ directory.
 	const { cookies, draftMode } = await import("next/headers")
 
+	// `next/navigation` must stay a bare specifier for Next.js to alias it on the
+	// server (see tsdown.config.ts), but Node.js cannot resolve bare `next/*`
+	// imports. A dynamic import is only resolved when this function runs.
+	const { redirect } = await import("next/navigation")
+
 	const documentID = request.nextUrl.searchParams.get("documentId") ?? undefined
 
 	// Set the initial preview cookie. Setting the cookie here is necessary
@@ -62,5 +66,5 @@ export async function redirectToPreviewURL(config: RedirectToPreviewURLConfig): 
 
 	;(await draftMode()).enable()
 
-	redirect(previewURL)
+	return redirect(previewURL)
 }

--- a/src/redirectToPreviewURL.ts
+++ b/src/redirectToPreviewURL.ts
@@ -40,9 +40,8 @@ export async function redirectToPreviewURL(config: RedirectToPreviewURLConfig): 
 	// in a Server Component which is not supported in the pages/ directory.
 	const { cookies, draftMode } = await import("next/headers")
 
-	// `next/navigation` must stay a bare specifier for Next.js to alias it on the
-	// server (see tsdown.config.ts), but Node.js cannot resolve bare `next/*`
-	// imports. A dynamic import is only resolved when this function runs.
+	// Dynamic so Node.js can load this module: the bare specifier (kept by
+	// tsdown.config.ts for Next.js's server alias) is not resolvable by Node.js.
 	const { redirect } = await import("next/navigation")
 
 	const documentID = request.nextUrl.searchParams.get("documentId") ?? undefined

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -32,7 +32,6 @@ for (const name of ["app-router", "pages-router", "next-15"]) {
 		})
 
 		test("tree-shakes unused exports", () => {
-			test.fail(true, "https://github.com/prismicio/prismic-next/issues/142")
 			const dir = join(project, ".next/static/chunks")
 			const js = readdirSync(dir, { recursive: true, encoding: "utf8" })
 				.filter((file) => file.endsWith(".js"))

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,9 +10,13 @@ export default defineConfig({
 	unbundle: true,
 	plugins: [
 		{
+			// Next.js aliases `next/navigation` (not `next/navigation.js`) to its
+			// server build. Keep the bare specifier for the dynamic import in
+			// `redirectToPreviewURL`. Static imports get `.js` so Node.js can load
+			// the ESM build.
 			name: "next-navigation-specifier",
-			resolveId(id) {
-				if (id === "next/navigation") {
+			resolveId(id, _importer, { kind }) {
+				if (id === "next/navigation" && kind === "dynamic-import") {
 					return { id: "next/navigation", external: true }
 				}
 			},

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,10 +10,9 @@ export default defineConfig({
 	unbundle: true,
 	plugins: [
 		{
-			// Next.js aliases `next/navigation` (not `next/navigation.js`) to its
-			// server build. Keep the bare specifier for the dynamic import in
-			// `redirectToPreviewURL`. Static imports get `.js` so Node.js can load
-			// the ESM build.
+			// Next.js aliases `next/navigation` (not `next/navigation.js`) on the server.
+			// Keep it bare only for the dynamic import in `redirectToPreviewURL`; static
+			// imports get `.js` so Node.js can load the ESM build.
 			name: "next-navigation-specifier",
 			resolveId(id, _importer, { kind }) {
 				if (id === "next/navigation" && kind === "dynamic-import") {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: #142

### Description

When an app imports one component from `@prismicio/next`, the browser bundle gets every export and all of `@prismicio/client`. #130 removed the `import` condition from the `exports` map, so bundlers get the CJS build. Bundlers cannot tree-shake the CJS build.

This PR restores the `import` condition so bundlers get the ESM build. It also makes the ESM build loadable by Node.js. That is the part that broke in #105 and #129 the last time the `import` condition existed. This PR supersedes #143.

The table shows the first-load JS for the `/PrismicNextImage/client` route in the `app-router` e2e project, from `next build --experimental-analyze`. This is the full bundle for the route. The Prismic packages are a small part of it. The difference is the preview and simulator code that the route does not use. This shows that tree shaking is active.

| | First-load JS | Preview and simulator code in the route |
| --- | --- | --- |
| `main` | 599 KB | Yes |
| This PR | 520 KB | No |

The `build` Playwright project from #144 now passes on Next.js 15 and 16, with the `test.fail()` annotations removed.

```sh
npx playwright test --project build --reporter=list

  ✓  app-router (Next 16) › builds
  ✓  app-router (Next 16) › tree-shakes unused exports
  ✓  pages-router (Next 16) › builds
  ✓  pages-router (Next 16) › tree-shakes unused exports
  ✓  next-15 › builds
  ✓  next-15 › tree-shakes unused exports
  6 passed
```

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

1. Run `npm ci`.
2. Run `npx playwright test --project build`.
3. Make sure that all six tests pass.
4. Run `npm run e2e` with Prismic credentials. The preview tests use `redirectToPreviewURL` and `useRouter` at runtime.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches package entry resolution, preview redirect, and cache tagging across Next 15–16; regressions could affect bundle size, preview flows, or builds on older Next versions.
> 
> **Overview**
> Restores **`import` / `require` conditions** in `package.json` so bundlers resolve the ESM builds again (fixing tree-shaking / #142) instead of defaulting to CJS.
> 
> Makes the published **ESM output safe for Node and Next**: `redirectToPreviewURL` loads `redirect` via **dynamic** `import("next/navigation")`, and the tsdown plugin only keeps the bare `next/navigation` specifier for that dynamic import (static imports get `.js` for Node). **`cacheTagPrismicPages`** uses a namespace import from `next/cache` so linking does not break on Next 15 where `cacheTag` may be absent. **`lz-string`** switches to default imports in the simulator helpers for ESM interop.
> 
> The **build e2e** tree-shake test is re-enabled (removed `test.fail()`), expecting unused `@prismicio/next` exports (e.g. migration/write API URLs) to stay out of client chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2c3466ef578a3fb7c98534355d4d7680f6457b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
