### PR TITLE
fix: keep previews live in editor and standalone tabs

### DIFF
--- a/e2e-projects/app-router/app/api/get-preview-ref-test/route.ts
+++ b/e2e-projects/app-router/app/api/get-preview-ref-test/route.ts
@@ -1,11 +1,22 @@
 import { cookie as prismicCookie } from "@prismicio/client"
-import { getPreviewRef } from "@prismicio/next"
+import { getPreviewRef, redirectToPreviewURL } from "@prismicio/next"
 import { cookies, draftMode } from "next/headers"
 import { NextResponse, type NextRequest } from "next/server"
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
 	const mode = request.nextUrl.searchParams.get("mode")
 	const previewCookie = request.nextUrl.searchParams.get("previewCookie")
+	if (mode === "bootstrap") {
+		return await redirectToPreviewURL({
+			client: {
+				resolvePreviewURL: async () =>
+					request.nextUrl.searchParams.has("client")
+						? "/preview-client-test"
+						: "/api/get-preview-ref-test",
+			},
+			request,
+		})
+	}
 
 	if (previewCookie !== null) {
 		const cookieJar = await cookies()

--- a/e2e-projects/app-router/app/api/get-preview-ref-test/route.ts
+++ b/e2e-projects/app-router/app/api/get-preview-ref-test/route.ts
@@ -1,0 +1,28 @@
+import { cookie as prismicCookie } from "@prismicio/client"
+import { getPreviewRef } from "@prismicio/next"
+import { cookies, draftMode } from "next/headers"
+import { NextResponse, type NextRequest } from "next/server"
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+	const mode = request.nextUrl.searchParams.get("mode")
+	const previewCookie = request.nextUrl.searchParams.get("previewCookie")
+
+	if (previewCookie !== null) {
+		const cookieJar = await cookies()
+		cookieJar.set(prismicCookie.preview, previewCookie, { path: "/" })
+	}
+
+	if (mode === "enable") {
+		;(await draftMode()).enable()
+	}
+	if (mode === "disable") {
+		;(await draftMode()).disable()
+	}
+
+	const draft = await draftMode()
+
+	return NextResponse.json({
+		draftModeEnabled: draft.isEnabled,
+		previewRef: (await getPreviewRef()) ?? null,
+	})
+}

--- a/e2e-projects/app-router/app/preview-client-test/page.tsx
+++ b/e2e-projects/app-router/app/preview-client-test/page.tsx
@@ -1,0 +1,16 @@
+import { getPreviewRef, PrismicPreview } from "@prismicio/next"
+import { draftMode } from "next/headers"
+import type { JSX } from "react"
+
+export default async function Page(): Promise<JSX.Element> {
+	return (
+		<>
+			<p data-testid="draft-mode">{String((await draftMode()).isEnabled)}</p>
+			<p data-testid="preview-ref">{(await getPreviewRef()) ?? "none"}</p>
+			<PrismicPreview
+				repositoryName="example"
+				updatePreviewURL="/api/get-preview-ref-test?mode=bootstrap"
+			/>
+		</>
+	)
+}

--- a/e2e-projects/app-router/app/preview-recovery-test/layout.tsx
+++ b/e2e-projects/app-router/app/preview-recovery-test/layout.tsx
@@ -1,0 +1,13 @@
+import { PrismicPreview } from "@prismicio/next"
+import type { JSX, ReactNode } from "react"
+
+export default function Layout({ children }: { children: ReactNode }): JSX.Element {
+	return (
+		<PrismicPreview
+			repositoryName="example"
+			updatePreviewURL="/api/get-preview-ref-test?mode=bootstrap"
+		>
+			{children}
+		</PrismicPreview>
+	)
+}

--- a/e2e-projects/app-router/app/preview-recovery-test/not-found.tsx
+++ b/e2e-projects/app-router/app/preview-recovery-test/not-found.tsx
@@ -1,0 +1,5 @@
+import type { JSX } from "react"
+
+export default function NotFound(): JSX.Element {
+	return <h1>Document not found</h1>
+}

--- a/e2e-projects/app-router/app/preview-recovery-test/page.tsx
+++ b/e2e-projects/app-router/app/preview-recovery-test/page.tsx
@@ -1,0 +1,9 @@
+import { getPreviewRef } from "@prismicio/next"
+import { notFound } from "next/navigation"
+import type { JSX } from "react"
+
+export default async function Page(): Promise<JSX.Element> {
+	const ref = await getPreviewRef()
+	if (!ref) notFound()
+	return <p data-testid="preview-ref">{ref}</p>
+}

--- a/e2e-projects/pages-router/pages/api/set-preview-data-test.ts
+++ b/e2e-projects/pages-router/pages/api/set-preview-data-test.ts
@@ -1,0 +1,14 @@
+import { cookie as prismicCookie } from "@prismicio/client"
+import { setPreviewData } from "@prismicio/next/pages"
+import type { NextApiRequest, NextApiResponse } from "next"
+
+export default function handler(req: NextApiRequest, res: NextApiResponse): void {
+	const previewCookie = req.query.previewCookie
+	if (typeof previewCookie === "string") {
+		req.cookies[prismicCookie.preview] = previewCookie
+	}
+
+	setPreviewData({ req, res })
+
+	res.status(200).json({ ok: true })
+}

--- a/e2e-projects/pages-router/pages/api/set-preview-data-test.ts
+++ b/e2e-projects/pages-router/pages/api/set-preview-data-test.ts
@@ -3,12 +3,17 @@ import { setPreviewData } from "@prismicio/next/pages"
 import type { NextApiRequest, NextApiResponse } from "next"
 
 export default function handler(req: NextApiRequest, res: NextApiResponse): void {
+	res.setHeader("Set-Cookie", "unrelated=value; Path=/; HttpOnly; SameSite=Lax")
 	const previewCookie = req.query.previewCookie
 	if (typeof previewCookie === "string") {
 		req.cookies[prismicCookie.preview] = previewCookie
 	}
 
 	setPreviewData({ req, res })
+	if ("redirect" in req.query) {
+		res.redirect("/preview-client-test")
+		return
+	}
 
 	res.status(200).json({ ok: true })
 }

--- a/e2e-projects/pages-router/pages/preview-client-test.tsx
+++ b/e2e-projects/pages-router/pages/preview-client-test.tsx
@@ -1,0 +1,28 @@
+import { PrismicPreview } from "@prismicio/next/pages"
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next"
+import type { JSX } from "react"
+
+export default function Page({
+	previewRef,
+}: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+	return (
+		<>
+			<p data-testid="preview-ref">{previewRef ?? "none"}</p>
+			<PrismicPreview
+				repositoryName="example"
+				updatePreviewURL="/api/set-preview-data-test?redirect"
+			/>
+		</>
+	)
+}
+
+export const getServerSideProps: GetServerSideProps<{ previewRef: string | null }> = async ({
+	previewData,
+}) => ({
+	props: {
+		previewRef:
+			typeof previewData === "object" && previewData !== null && "ref" in previewData
+				? String(previewData.ref)
+				: null,
+	},
+})

--- a/e2e-projects/pages-router/pages/set-preview-data-test.tsx
+++ b/e2e-projects/pages-router/pages/set-preview-data-test.tsx
@@ -1,0 +1,20 @@
+import type { GetServerSideProps, InferGetServerSidePropsType } from "next"
+import type { JSX } from "react"
+
+type PreviewData = { ref?: unknown } | string | undefined
+
+export default function Page({
+	previewRef,
+}: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+	return <pre data-testid="preview-ref">{JSON.stringify(previewRef)}</pre>
+}
+
+export const getServerSideProps: GetServerSideProps<{ previewRef: unknown }> = async ({
+	previewData,
+}) => {
+	const data = previewData as PreviewData
+	const previewRef =
+		typeof data === "object" && data !== null && "ref" in data ? (data.ref ?? null) : null
+
+	return { props: { previewRef } }
+}

--- a/e2e-projects/pages-router/pages/set-preview-data-test.tsx
+++ b/e2e-projects/pages-router/pages/set-preview-data-test.tsx
@@ -3,6 +3,11 @@ import type { JSX } from "react"
 
 type PreviewData = { ref?: unknown } | string | undefined
 
+function previewRefFromPreviewData(previewData: unknown): unknown {
+	const data = previewData as PreviewData
+	return typeof data === "object" && data !== null && "ref" in data ? (data.ref ?? null) : null
+}
+
 export default function Page({
 	previewRef,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
@@ -11,10 +16,16 @@ export default function Page({
 
 export const getServerSideProps: GetServerSideProps<{ previewRef: unknown }> = async ({
 	previewData,
+	req,
+	res,
 }) => {
-	const data = previewData as PreviewData
-	const previewRef =
-		typeof data === "object" && data !== null && "ref" in data ? (data.ref ?? null) : null
+	const previewRef = previewRefFromPreviewData(previewData)
+
+	if (req.headers.accept?.includes("application/json")) {
+		res.setHeader("Content-Type", "application/json")
+		res.end(JSON.stringify({ previewRef }))
+		return { props: { previewRef } }
+	}
 
 	return { props: { previewRef } }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
 		},
 		{
 			name: "app-router",
-			testIgnore: ["cache-components.spec.ts", "build.spec.ts"],
+			testIgnore: ["cache-components.spec.ts", "build.spec.ts", "getPreviewRef.spec.ts"],
 			dependencies: ["setup"],
 			use: {
 				...devices["Desktop Chrome"],
@@ -50,12 +50,20 @@ export default defineConfig({
 		},
 		{
 			name: "pages-router",
-			testIgnore: ["cache-components.spec.ts", "build.spec.ts"],
+			testIgnore: ["cache-components.spec.ts", "build.spec.ts", "getPreviewRef.spec.ts"],
 			dependencies: ["setup", "app-router"],
 			use: {
 				...devices["Desktop Chrome"],
 				baseURL: "http://localhost:4322",
 				storageState: STORAGE_STATE,
+			},
+		},
+		{
+			name: "get-preview-ref",
+			testMatch: "getPreviewRef.spec.ts",
+			use: {
+				...devices["Desktop Chrome"],
+				baseURL: "http://localhost:4321",
 			},
 		},
 		{

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,12 @@ export default defineConfig({
 		},
 		{
 			name: "app-router",
-			testIgnore: ["cache-components.spec.ts", "build.spec.ts", "getPreviewRef.spec.ts"],
+			testIgnore: [
+				"cache-components.spec.ts",
+				"build.spec.ts",
+				"getPreviewRef.spec.ts",
+				"setPreviewData.spec.ts",
+			],
 			dependencies: ["setup"],
 			use: {
 				...devices["Desktop Chrome"],
@@ -50,7 +55,12 @@ export default defineConfig({
 		},
 		{
 			name: "pages-router",
-			testIgnore: ["cache-components.spec.ts", "build.spec.ts", "getPreviewRef.spec.ts"],
+			testIgnore: [
+				"cache-components.spec.ts",
+				"build.spec.ts",
+				"getPreviewRef.spec.ts",
+				"setPreviewData.spec.ts",
+			],
 			dependencies: ["setup", "app-router"],
 			use: {
 				...devices["Desktop Chrome"],
@@ -64,6 +74,14 @@ export default defineConfig({
 			use: {
 				...devices["Desktop Chrome"],
 				baseURL: "http://localhost:4321",
+			},
+		},
+		{
+			name: "set-preview-data",
+			testMatch: "setPreviewData.spec.ts",
+			use: {
+				...devices["Desktop Chrome"],
+				baseURL: "http://localhost:4322",
 			},
 		},
 		{

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,8 @@ export default defineConfig({
 				"build.spec.ts",
 				"getPreviewRef.spec.ts",
 				"setPreviewData.spec.ts",
+				"previewClient.spec.ts",
+				"pagesPreviewClient.spec.ts",
 			],
 			dependencies: ["setup"],
 			use: {
@@ -60,6 +62,8 @@ export default defineConfig({
 				"build.spec.ts",
 				"getPreviewRef.spec.ts",
 				"setPreviewData.spec.ts",
+				"previewClient.spec.ts",
+				"pagesPreviewClient.spec.ts",
 			],
 			dependencies: ["setup", "app-router"],
 			use: {
@@ -70,7 +74,7 @@ export default defineConfig({
 		},
 		{
 			name: "get-preview-ref",
-			testMatch: "getPreviewRef.spec.ts",
+			testMatch: ["getPreviewRef.spec.ts", "previewClient.spec.ts"],
 			use: {
 				...devices["Desktop Chrome"],
 				baseURL: "http://localhost:4321",
@@ -78,7 +82,7 @@ export default defineConfig({
 		},
 		{
 			name: "set-preview-data",
-			testMatch: "setPreviewData.spec.ts",
+			testMatch: ["setPreviewData.spec.ts", "pagesPreviewClient.spec.ts"],
 			use: {
 				...devices["Desktop Chrome"],
 				baseURL: "http://localhost:4322",

--- a/src/PrismicPreviewClient.tsx
+++ b/src/PrismicPreviewClient.tsx
@@ -24,6 +24,9 @@ export const PrismicPreviewClient: FC<PrismicPreviewClientProps> = (props) => {
 
 	useEffect(() => {
 		const controller = new AbortController()
+		let starting: Promise<void> | undefined
+		let startController: AbortController | undefined
+		let ending = false
 
 		window.addEventListener("prismicPreviewUpdate", onUpdate, {
 			signal: controller.signal,
@@ -42,14 +45,21 @@ export const PrismicPreviewClient: FC<PrismicPreviewClientProps> = (props) => {
 		// share links do not go to the `updatePreviewURL` like a normal
 		// preview.
 		if (hasCookieForRepository && !isDraftMode) {
+			start()
+		}
+
+		function start() {
+			if (starting) return
+			startController = new AbortController()
+
 			// We check `opaqueredirect` because we don't care if
 			// the redirect was successful or not. As long as it
 			// redirects, we know the endpoint exists and draft mode
 			// is active.
-			globalThis
+			starting = globalThis
 				.fetch(updatePreviewURL, {
 					redirect: "manual",
-					signal: controller.signal,
+					signal: startController.signal,
 				})
 				.then((res) => {
 					if (res.type !== "opaqueredirect") {
@@ -60,20 +70,35 @@ export const PrismicPreviewClient: FC<PrismicPreviewClientProps> = (props) => {
 						return
 					}
 
-					refresh()
+					// A soft refresh does not reset Next.js's not-found boundary
+					// when an unpublished page enters Draft Mode at the same URL.
+					// Only this initial activation navigates; active previews stay soft.
+					window.location.reload()
 				})
 				.catch(() => {
 					// noop
+				})
+				.finally(() => {
+					starting = undefined
+					startController = undefined
 				})
 		}
 
 		function onUpdate(event: Event) {
 			event.preventDefault()
-			refresh()
+			if (ending) return
+			if (isDraftMode) {
+				refresh()
+			} else {
+				start()
+			}
 		}
 
 		function onEnd(event: Event) {
 			event.preventDefault()
+			if (ending) return
+			ending = true
+			startController?.abort()
 			globalThis
 				.fetch(exitPreviewURL, { signal: controller.signal })
 				.then((res) => {
@@ -90,9 +115,15 @@ export const PrismicPreviewClient: FC<PrismicPreviewClientProps> = (props) => {
 				.catch(() => {
 					// noop
 				})
+				.finally(() => {
+					ending = false
+				})
 		}
 
-		return () => controller.abort()
+		return () => {
+			controller.abort()
+			startController?.abort()
+		}
 	}, [repositoryName, isDraftMode, updatePreviewURL, exitPreviewURL, refresh])
 
 	return null

--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -24,8 +24,15 @@ export async function exitPreview(): Promise<Response> {
 	;(await draftMode()).disable()
 
 	// `redirectToPreviewURL` writes the preview cookie, so `exitPreview`
-	// clears it to close the preview-cookie loop.
-	;(await cookies()).delete(prismicCookie.preview)
+	// clears it to close the preview-cookie loop. Attributes must match
+	// the write so the browser expires the cookie, including inside a
+	// cross-site iframe.
+	;(await cookies()).delete({
+		name: prismicCookie.preview,
+		path: "/",
+		sameSite: "none",
+		secure: true,
+	})
 
 	// `Cache-Control` header is used to prevent CDN-level caching.
 	return new Response(JSON.stringify({ success: true }), {

--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -1,9 +1,4 @@
-import { cookie as prismicCookie } from "@prismicio/client"
-
-import {
-	expiredPreviewCookieHeaders,
-	expiredPreviewCookieSetOptions,
-} from "./lib/expiredPreviewCookies"
+import { expiredPreviewCookieHeaders } from "./lib/expiredPreviewCookies"
 
 /**
  * Ends a Prismic preview session within a Next.js app. This function should be used in a Router
@@ -24,20 +19,15 @@ export async function exitPreview(): Promise<Response> {
 	// Need this to avoid the following Next.js build-time error:
 	// You're importing a component that needs next/headers. That only works
 	// in a Server Component which is not supported in the pages/ directory.
-	const { cookies, draftMode } = await import("next/headers")
+	const { draftMode } = await import("next/headers")
 
 	;(await draftMode()).disable()
 
 	// `redirectToPreviewURL` writes SameSite=None; Secure. The toolbar may
 	// leave SameSite=Lax (not Secure). Those are different cookies to Chrome.
-	// Expire both. Do not use `cookies().delete()`: on Next.js 13.4.5–15 it
-	// omits Secure/SameSite. `cookies()` is name-keyed, so also emit both
-	// Set-Cookie headers on the Response.
-	const cookieJar = await cookies()
-	for (const options of expiredPreviewCookieSetOptions) {
-		cookieJar.set(prismicCookie.preview, "", options)
-	}
-
+	// Expire both on the Response. Do not use `cookies().set` / `delete()`:
+	// ResponseCookies is name-keyed, so a second `io.prismic.preview` overwrites
+	// the first and the Lax leftover survives.
 	const headers = new Headers({
 		"Cache-Control": "no-store",
 	})

--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -24,14 +24,18 @@ export async function exitPreview(): Promise<Response> {
 	;(await draftMode()).disable()
 
 	// `redirectToPreviewURL` writes the preview cookie, so `exitPreview`
-	// clears it to close the preview-cookie loop. Attributes must match
-	// the write so the browser expires the cookie, including inside a
-	// cross-site iframe.
-	;(await cookies()).delete({
-		name: prismicCookie.preview,
+	// clears it to close the preview-cookie loop.
+	//
+	// Do not use `cookies().delete()`: on Next.js 13.4.5–15 it omits
+	// Secure/SameSite, so Chrome will not replace the iframe cookie
+	// (SameSite=None; Secure). Overwrite with an expired cookie that
+	// matches the write attributes instead.
+	;(await cookies()).set(prismicCookie.preview, "", {
 		path: "/",
 		sameSite: "none",
 		secure: true,
+		httpOnly: false,
+		expires: new Date(0),
 	})
 
 	// `Cache-Control` header is used to prevent CDN-level caching.

--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -1,4 +1,7 @@
-import { expiredPreviewCookieHeaders } from "./lib/expiredPreviewCookies"
+import {
+	expiredDraftModeCookieHeaders,
+	expiredPreviewCookieHeaders,
+} from "./lib/expiredPreviewCookies"
 
 /**
  * Ends a Prismic preview session within a Next.js app. This function should be used in a Router
@@ -16,22 +19,15 @@ import { expiredPreviewCookieHeaders } from "./lib/expiredPreviewCookies"
  * 	```
  */
 export async function exitPreview(): Promise<Response> {
-	// Need this to avoid the following Next.js build-time error:
-	// You're importing a component that needs next/headers. That only works
-	// in a Server Component which is not supported in the pages/ directory.
-	const { draftMode } = await import("next/headers")
-
-	;(await draftMode()).disable()
-
-	// `redirectToPreviewURL` writes SameSite=None; Secure. The toolbar may
-	// leave SameSite=Lax (not Secure). Those are different cookies to Chrome.
-	// Expire both on the Response. Do not use `cookies().set` / `delete()`:
-	// ResponseCookies is name-keyed, so a second `io.prismic.preview` overwrites
-	// the first and the Lax leftover survives.
+	// Do not call `cookies()` or `draftMode().disable()`. ResponseCookies is
+	// name-keyed: `appendMutableCookies` rebuilds Set-Cookie by name and drops
+	// the extra Lax expire. Emit every expire on the Response instead:
+	// toolbar Lax + iframe None; Secure for `io.prismic.preview`, and both
+	// shapes of `__prerender_bypass` that `disable()` would have cleared.
 	const headers = new Headers({
 		"Cache-Control": "no-store",
 	})
-	for (const setCookie of expiredPreviewCookieHeaders()) {
+	for (const setCookie of [...expiredPreviewCookieHeaders(), ...expiredDraftModeCookieHeaders()]) {
 		headers.append("Set-Cookie", setCookie)
 	}
 

--- a/src/exitPreview.ts
+++ b/src/exitPreview.ts
@@ -1,5 +1,10 @@
 import { cookie as prismicCookie } from "@prismicio/client"
 
+import {
+	expiredPreviewCookieHeaders,
+	expiredPreviewCookieSetOptions,
+} from "./lib/expiredPreviewCookies"
+
 /**
  * Ends a Prismic preview session within a Next.js app. This function should be used in a Router
  * Handler.
@@ -23,25 +28,22 @@ export async function exitPreview(): Promise<Response> {
 
 	;(await draftMode()).disable()
 
-	// `redirectToPreviewURL` writes the preview cookie, so `exitPreview`
-	// clears it to close the preview-cookie loop.
-	//
-	// Do not use `cookies().delete()`: on Next.js 13.4.5–15 it omits
-	// Secure/SameSite, so Chrome will not replace the iframe cookie
-	// (SameSite=None; Secure). Overwrite with an expired cookie that
-	// matches the write attributes instead.
-	;(await cookies()).set(prismicCookie.preview, "", {
-		path: "/",
-		sameSite: "none",
-		secure: true,
-		httpOnly: false,
-		expires: new Date(0),
-	})
+	// `redirectToPreviewURL` writes SameSite=None; Secure. The toolbar may
+	// leave SameSite=Lax (not Secure). Those are different cookies to Chrome.
+	// Expire both. Do not use `cookies().delete()`: on Next.js 13.4.5–15 it
+	// omits Secure/SameSite. `cookies()` is name-keyed, so also emit both
+	// Set-Cookie headers on the Response.
+	const cookieJar = await cookies()
+	for (const options of expiredPreviewCookieSetOptions) {
+		cookieJar.set(prismicCookie.preview, "", options)
+	}
 
-	// `Cache-Control` header is used to prevent CDN-level caching.
-	return new Response(JSON.stringify({ success: true }), {
-		headers: {
-			"Cache-Control": "no-store",
-		},
+	const headers = new Headers({
+		"Cache-Control": "no-store",
 	})
+	for (const setCookie of expiredPreviewCookieHeaders()) {
+		headers.append("Set-Cookie", setCookie)
+	}
+
+	return new Response(JSON.stringify({ success: true }), { headers })
 }

--- a/src/getPreviewRef.ts
+++ b/src/getPreviewRef.ts
@@ -1,5 +1,7 @@
 import { cookie as prismicCookie } from "@prismicio/client"
 
+import { previewRefFromCookie } from "./lib/previewRefFromCookie"
+
 /**
  * Reads the Prismic preview ref for the current request when an active preview session exists.
  *
@@ -46,37 +48,4 @@ export async function getPreviewRef(): Promise<string | undefined> {
 	// toolbar jar (`{ "<repo>.prismic.io": { preview } }`). Only `preview` is a
 	// Content API ref; the jar string is not.
 	return previewRefFromCookie(cookie)
-}
-
-/**
- * Unwraps `io.prismic.preview` to a Content API ref.
- *
- * After toolbar `PreviewCookie.sync` / `upsertPreviewForDomain`, the cookie is
- * `{ [domain]: { preview: string } }`. Returning that jar makes `enableAutoPreviews`
- * / Cache Components send a non-ref (ParsingError / 404).
- */
-function previewRefFromCookie(cookie: string): string | undefined {
-	try {
-		const parsed: unknown = JSON.parse(cookie)
-		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-			return
-		}
-
-		const previewRefs: string[] = []
-		for (const value of Object.values(parsed)) {
-			if (
-				value !== null &&
-				typeof value === "object" &&
-				!Array.isArray(value) &&
-				"preview" in value &&
-				typeof value.preview === "string"
-			) {
-				previewRefs.push(value.preview)
-			}
-		}
-
-		return previewRefs.length === 1 ? previewRefs[0] : undefined
-	} catch {
-		return cookie
-	}
 }

--- a/src/getPreviewRef.ts
+++ b/src/getPreviewRef.ts
@@ -42,6 +42,38 @@ export async function getPreviewRef(): Promise<string | undefined> {
 		return
 	}
 
-	// Draft Mode gates preview reads; the Content API validates the opaque ref.
-	return cookie
+	// Draft Mode gates preview reads. The cookie may be a raw token or the
+	// toolbar jar (`{ "<repo>.prismic.io": { preview } }`). Only `preview` is a
+	// Content API ref; the jar string is not.
+	return previewRefFromCookie(cookie)
+}
+
+/**
+ * Unwraps `io.prismic.preview` to a Content API ref.
+ *
+ * After toolbar `PreviewCookie.sync` / `upsertPreviewForDomain`, the cookie is
+ * `{ [domain]: { preview: string } }`. Returning that jar makes `enableAutoPreviews`
+ * / Cache Components send a non-ref (ParsingError / 404).
+ */
+function previewRefFromCookie(cookie: string): string | undefined {
+	try {
+		const parsed: unknown = JSON.parse(cookie)
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return
+		}
+
+		for (const value of Object.values(parsed)) {
+			if (
+				value !== null &&
+				typeof value === "object" &&
+				!Array.isArray(value) &&
+				"preview" in value &&
+				typeof value.preview === "string"
+			) {
+				return value.preview
+			}
+		}
+	} catch {
+		return cookie
+	}
 }

--- a/src/getPreviewRef.ts
+++ b/src/getPreviewRef.ts
@@ -42,10 +42,6 @@ export async function getPreviewRef(): Promise<string | undefined> {
 		return
 	}
 
-	const isActiveCookie = cookie.includes("websitePreviewId=")
-	if (!isActiveCookie) {
-		return
-	}
-
+	// Draft Mode gates preview reads; the Content API validates the opaque ref.
 	return cookie
 }

--- a/src/getPreviewRef.ts
+++ b/src/getPreviewRef.ts
@@ -62,6 +62,7 @@ function previewRefFromCookie(cookie: string): string | undefined {
 			return
 		}
 
+		const previewRefs: string[] = []
 		for (const value of Object.values(parsed)) {
 			if (
 				value !== null &&
@@ -70,9 +71,11 @@ function previewRefFromCookie(cookie: string): string | undefined {
 				"preview" in value &&
 				typeof value.preview === "string"
 			) {
-				return value.preview
+				previewRefs.push(value.preview)
 			}
 		}
+
+		return previewRefs.length === 1 ? previewRefs[0] : undefined
 	} catch {
 		return cookie
 	}

--- a/src/lib/expiredPreviewCookies.ts
+++ b/src/lib/expiredPreviewCookies.ts
@@ -2,12 +2,31 @@ import { cookie as prismicCookie } from "@prismicio/client"
 
 const epoch = new Date(0)
 
+function expiresAttr(): string {
+	return `Expires=${epoch.toUTCString()}`
+}
+
 /** Expired `Set-Cookie` values for both leftover `io.prismic.preview` shapes. */
 export function expiredPreviewCookieHeaders(name = prismicCookie.preview): string[] {
-	const expires = `Expires=${epoch.toUTCString()}`
+	const expires = expiresAttr()
 
 	return [
 		`${name}=; Path=/; ${expires}; SameSite=Lax`,
 		`${name}=; Path=/; ${expires}; SameSite=None; Secure`,
+	]
+}
+
+/**
+ * Expired `Set-Cookie` values for the App Router draft-mode cookie that `draftMode().disable()`
+ * would clear. Next sets `__prerender_bypass` as Lax (not Secure) in development and SameSite=None;
+ * Secure in production.
+ */
+export function expiredDraftModeCookieHeaders(): string[] {
+	const expires = expiresAttr()
+	const name = "__prerender_bypass"
+
+	return [
+		`${name}=; Path=/; ${expires}; SameSite=Lax; HttpOnly`,
+		`${name}=; Path=/; ${expires}; SameSite=None; Secure; HttpOnly`,
 	]
 }

--- a/src/lib/expiredPreviewCookies.ts
+++ b/src/lib/expiredPreviewCookies.ts
@@ -2,30 +2,6 @@ import { cookie as prismicCookie } from "@prismicio/client"
 
 const epoch = new Date(0)
 
-/**
- * `cookies().set` options that expire both leftover shapes of `io.prismic.preview`: toolbar Lax
- * (not Secure) and the iframe write (SameSite=None; Secure).
- *
- * `cookies()` is name-keyed, so a Route Handler must also emit both `Set-Cookie` headers from
- * {@link expiredPreviewCookieHeaders}.
- */
-export const expiredPreviewCookieSetOptions = [
-	{
-		path: "/",
-		sameSite: "lax",
-		secure: false,
-		httpOnly: false,
-		expires: epoch,
-	},
-	{
-		path: "/",
-		sameSite: "none",
-		secure: true,
-		httpOnly: false,
-		expires: epoch,
-	},
-] as const
-
 /** Expired `Set-Cookie` values for both leftover `io.prismic.preview` shapes. */
 export function expiredPreviewCookieHeaders(name = prismicCookie.preview): string[] {
 	const expires = `Expires=${epoch.toUTCString()}`

--- a/src/lib/expiredPreviewCookies.ts
+++ b/src/lib/expiredPreviewCookies.ts
@@ -1,0 +1,37 @@
+import { cookie as prismicCookie } from "@prismicio/client"
+
+const epoch = new Date(0)
+
+/**
+ * `cookies().set` options that expire both leftover shapes of `io.prismic.preview`: toolbar Lax
+ * (not Secure) and the iframe write (SameSite=None; Secure).
+ *
+ * `cookies()` is name-keyed, so a Route Handler must also emit both `Set-Cookie` headers from
+ * {@link expiredPreviewCookieHeaders}.
+ */
+export const expiredPreviewCookieSetOptions = [
+	{
+		path: "/",
+		sameSite: "lax",
+		secure: false,
+		httpOnly: false,
+		expires: epoch,
+	},
+	{
+		path: "/",
+		sameSite: "none",
+		secure: true,
+		httpOnly: false,
+		expires: epoch,
+	},
+] as const
+
+/** Expired `Set-Cookie` values for both leftover `io.prismic.preview` shapes. */
+export function expiredPreviewCookieHeaders(name = prismicCookie.preview): string[] {
+	const expires = `Expires=${epoch.toUTCString()}`
+
+	return [
+		`${name}=; Path=/; ${expires}; SameSite=Lax`,
+		`${name}=; Path=/; ${expires}; SameSite=None; Secure`,
+	]
+}

--- a/src/lib/expiredPreviewCookies.ts
+++ b/src/lib/expiredPreviewCookies.ts
@@ -30,3 +30,8 @@ export function expiredDraftModeCookieHeaders(): string[] {
 		`${name}=; Path=/; ${expires}; SameSite=None; Secure; HttpOnly`,
 	]
 }
+
+/** Expire Pages Router's signed preview data in development and production. */
+export function expiredPreviewDataCookieHeaders(): string[] {
+	return expiredPreviewCookieHeaders("__next_preview_data").map((header) => `${header}; HttpOnly`)
+}

--- a/src/lib/previewRefFromCookie.ts
+++ b/src/lib/previewRefFromCookie.ts
@@ -1,0 +1,33 @@
+/**
+ * Unwraps `io.prismic.preview` to a Content API ref.
+ *
+ * After toolbar `PreviewCookie.sync` / `upsertPreviewForDomain`, the cookie is
+ * `{ [domain]: { preview: string } }`. Returning that jar makes `enableAutoPreviews`
+ * / Cache Components send a non-ref (ParsingError / 404). A jar with more than one
+ * repository `preview` is ambiguous and is ignored.
+ */
+export function previewRefFromCookie(cookie: string): string | undefined {
+	try {
+		const parsed: unknown = JSON.parse(cookie)
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return
+		}
+
+		const previewRefs: string[] = []
+		for (const value of Object.values(parsed)) {
+			if (
+				value !== null &&
+				typeof value === "object" &&
+				!Array.isArray(value) &&
+				"preview" in value &&
+				typeof value.preview === "string"
+			) {
+				previewRefs.push(value.preview)
+			}
+		}
+
+		return previewRefs.length === 1 ? previewRefs[0] : undefined
+	} catch {
+		return cookie
+	}
+}

--- a/src/pages/PrismicPreview.tsx
+++ b/src/pages/PrismicPreview.tsx
@@ -50,6 +50,10 @@ export const PrismicPreview: FC<PrismicPreviewProps> = (props) => {
 
 	useEffect(() => {
 		const controller = new AbortController()
+		let starting: Promise<void> | undefined
+		let startController: AbortController | undefined
+		let updateRequested = false
+		let ending = false
 
 		window.addEventListener("prismicPreviewUpdate", onUpdate, {
 			signal: controller.signal,
@@ -74,6 +78,10 @@ export const PrismicPreview: FC<PrismicPreviewProps> = (props) => {
 
 		function onEnd(event: Event) {
 			event.preventDefault()
+			if (ending) return
+			ending = true
+			updateRequested = false
+			startController?.abort()
 			fetch(router.basePath + exitPreviewURL, { signal: controller.signal })
 				.then((res) => {
 					if (!res.ok) {
@@ -87,41 +95,60 @@ export const PrismicPreview: FC<PrismicPreviewProps> = (props) => {
 					refresh()
 				})
 				.catch(() => {})
+				.finally(() => {
+					ending = false
+				})
 		}
 
 		function onUpdate(event: Event) {
 			event.preventDefault()
+			if (ending) return
 			start()
 		}
 
 		function start() {
+			updateRequested = true
+			if (starting) return
+			const requestController = new AbortController()
+			startController = requestController
+
 			// We check `opaqueredirect` because we don't care if
 			// the redirect was successful or not. As long as it
 			// redirects, we know the endpoint exists and at least
 			// attempted to set preview data.
-			fetch(router.basePath + updatePreviewURL, {
-				redirect: "manual",
-				signal: controller.signal,
-			})
-				.then((res) => {
+			starting = (async () => {
+				do {
+					updateRequested = false
+					const res = await fetch(router.basePath + updatePreviewURL, {
+						redirect: "manual",
+						signal: requestController.signal,
+					})
 					if (res.type !== "opaqueredirect") {
 						console.error(
 							`[<PrismicPreview>] Failed to start or update the preview using "${updatePreviewURL}". Does it exist?`,
 						)
-
 						return
 					}
-
-					refresh()
-				})
+					// Preview Data captures the cookie when the request starts.
+					// If edits arrived meanwhile, store the latest ref before rendering.
+				} while (updateRequested && !requestController.signal.aborted)
+				if (!requestController.signal.aborted) refresh()
+			})()
 				.catch(() => {})
+				.finally(() => {
+					starting = undefined
+					startController = undefined
+				})
 		}
 
 		function refresh() {
 			router.replace(router.asPath, undefined, { scroll: false })
 		}
 
-		return () => controller.abort()
+		return () => {
+			controller.abort()
+			startController?.abort()
+		}
 	}, [exitPreviewURL, updatePreviewURL, repositoryName, router])
 
 	return (

--- a/src/pages/exitPreview.ts
+++ b/src/pages/exitPreview.ts
@@ -1,3 +1,5 @@
+import { cookie as prismicCookie } from "@prismicio/client"
+
 import type { NextApiRequestLike, NextApiResponseLike } from "./types"
 
 /** Configuration for `exitPreview()`. */
@@ -34,6 +36,28 @@ export type ExitPreviewAPIRouteConfig = {
  */
 export function exitPreview(config: ExitPreviewAPIRouteConfig): void {
 	config.res.clearPreviewData()
+
+	// `clearPreviewData()` only clears Next.js preview cookies. The toolbar
+	// (or a prior App write) can leave `io.prismic.preview`. If it survives,
+	// `<PrismicPreview>` calls `start()` → `/api/preview` and preview returns.
+	//
+	// Append an expired Set-Cookie with the App write attributes
+	// (Path=/; SameSite=None; Secure; not HttpOnly). Do not use
+	// `cookies().set` — that is the App Router helper. Do not replace the
+	// existing Set-Cookie header from `clearPreviewData()`.
+	const expiredPreviewCookie = `${prismicCookie.preview}=; Path=/; Expires=${new Date(0).toUTCString()}; SameSite=None; Secure`
+	const existingSetCookie = config.res.getHeader("Set-Cookie")
+	config.res.setHeader(
+		"Set-Cookie",
+		existingSetCookie == null
+			? expiredPreviewCookie
+			: [
+					...(Array.isArray(existingSetCookie) ? existingSetCookie : [existingSetCookie]).map(
+						String,
+					),
+					expiredPreviewCookie,
+				],
+	)
 
 	// `Cache-Control` header is used to prevent CDN-level caching.
 	config.res.setHeader("Cache-Control", "no-store")

--- a/src/pages/exitPreview.ts
+++ b/src/pages/exitPreview.ts
@@ -1,4 +1,8 @@
-import { expiredPreviewCookieHeaders } from "../lib/expiredPreviewCookies"
+import {
+	expiredDraftModeCookieHeaders,
+	expiredPreviewCookieHeaders,
+	expiredPreviewDataCookieHeaders,
+} from "../lib/expiredPreviewCookies"
 import type { NextApiRequestLike, NextApiResponseLike } from "./types"
 
 /** Configuration for `exitPreview()`. */
@@ -40,10 +44,16 @@ export function exitPreview(config: ExitPreviewAPIRouteConfig): void {
 	// leftover `io.prismic.preview` shapes (toolbar Lax, not Secure; and the
 	// iframe SameSite=None; Secure write). If either survives,
 	// `<PrismicPreview>` calls `start()` → `/api/preview` and preview returns.
+	// Next also emits Lax expiries in development, so explicitly clear the
+	// Secure Next preview cookies written by `setPreviewData()`.
 	// Do not use `cookies().set` — that is the App Router helper. Do not
 	// replace the existing Set-Cookie header from `clearPreviewData()`.
 	const existingSetCookie = config.res.getHeader("Set-Cookie")
-	const expiredPreviewCookies = expiredPreviewCookieHeaders()
+	const expiredPreviewCookies = [
+		...expiredPreviewCookieHeaders(),
+		...expiredDraftModeCookieHeaders(),
+		...expiredPreviewDataCookieHeaders(),
+	]
 	config.res.setHeader(
 		"Set-Cookie",
 		existingSetCookie == null

--- a/src/pages/exitPreview.ts
+++ b/src/pages/exitPreview.ts
@@ -1,5 +1,4 @@
-import { cookie as prismicCookie } from "@prismicio/client"
-
+import { expiredPreviewCookieHeaders } from "../lib/expiredPreviewCookies"
 import type { NextApiRequestLike, NextApiResponseLike } from "./types"
 
 /** Configuration for `exitPreview()`. */
@@ -37,25 +36,23 @@ export type ExitPreviewAPIRouteConfig = {
 export function exitPreview(config: ExitPreviewAPIRouteConfig): void {
 	config.res.clearPreviewData()
 
-	// `clearPreviewData()` only clears Next.js preview cookies. The toolbar
-	// (or a prior App write) can leave `io.prismic.preview`. If it survives,
+	// `clearPreviewData()` only clears Next.js preview cookies. Expire both
+	// leftover `io.prismic.preview` shapes (toolbar Lax, not Secure; and the
+	// iframe SameSite=None; Secure write). If either survives,
 	// `<PrismicPreview>` calls `start()` → `/api/preview` and preview returns.
-	//
-	// Append an expired Set-Cookie with the App write attributes
-	// (Path=/; SameSite=None; Secure; not HttpOnly). Do not use
-	// `cookies().set` — that is the App Router helper. Do not replace the
-	// existing Set-Cookie header from `clearPreviewData()`.
-	const expiredPreviewCookie = `${prismicCookie.preview}=; Path=/; Expires=${new Date(0).toUTCString()}; SameSite=None; Secure`
+	// Do not use `cookies().set` — that is the App Router helper. Do not
+	// replace the existing Set-Cookie header from `clearPreviewData()`.
 	const existingSetCookie = config.res.getHeader("Set-Cookie")
+	const expiredPreviewCookies = expiredPreviewCookieHeaders()
 	config.res.setHeader(
 		"Set-Cookie",
 		existingSetCookie == null
-			? expiredPreviewCookie
+			? expiredPreviewCookies
 			: [
 					...(Array.isArray(existingSetCookie) ? existingSetCookie : [existingSetCookie]).map(
 						String,
 					),
-					expiredPreviewCookie,
+					...expiredPreviewCookies,
 				],
 	)
 

--- a/src/pages/setPreviewData.ts
+++ b/src/pages/setPreviewData.ts
@@ -1,5 +1,6 @@
 import { cookie } from "@prismicio/client"
 
+import { previewRefFromCookie } from "../lib/previewRefFromCookie"
 import type { NextApiRequestLike, NextApiResponseLike } from "./types"
 
 /** Configuration for `setPreviewData`. */
@@ -21,8 +22,19 @@ export type SetPreviewDataConfig = {
 
 /** Set Prismic preview data for Next.js's Preview Mode. */
 export function setPreviewData({ req, res }: SetPreviewDataConfig): void {
-	const ref = req.query.token || req.cookies[cookie.preview]
+	const token = req.query.token
+	if (token) {
+		res.setPreviewData({ ref: token })
+		return
+	}
 
+	// Cookie-only path: unwrap the toolbar jar. `token` stays as-is above.
+	const previewCookie = req.cookies[cookie.preview]
+	if (!previewCookie) {
+		return
+	}
+
+	const ref = previewRefFromCookie(previewCookie)
 	if (ref) {
 		res.setPreviewData({ ref })
 	}

--- a/src/pages/setPreviewData.ts
+++ b/src/pages/setPreviewData.ts
@@ -22,20 +22,25 @@ export type SetPreviewDataConfig = {
 
 /** Set Prismic preview data for Next.js's Preview Mode. */
 export function setPreviewData({ req, res }: SetPreviewDataConfig): void {
-	const token = req.query.token
-	if (token) {
-		res.setPreviewData({ ref: token })
-		return
-	}
-
-	// Cookie-only path: unwrap the toolbar jar. `token` stays as-is above.
+	// Only unwrap the cookie. Query tokens, including arrays, stay as-is.
 	const previewCookie = req.cookies[cookie.preview]
-	if (!previewCookie) {
-		return
-	}
-
-	const ref = previewRefFromCookie(previewCookie)
+	const ref = req.query.token || (previewCookie && previewRefFromCookie(previewCookie))
 	if (ref) {
 		res.setPreviewData({ ref })
+
+		// Next.js uses Lax preview cookies in development. Preserve its
+		// signed/encrypted values and all other attributes, but allow both
+		// cookies to reach the site inside the editor's cross-site iframe.
+		const setCookie = res.getHeader("Set-Cookie")
+		if (typeof setCookie === "string" || Array.isArray(setCookie)) {
+			res.setHeader(
+				"Set-Cookie",
+				(typeof setCookie === "string" ? [setCookie] : setCookie).map((header) =>
+					/^__(?:prerender_bypass|next_preview_data)=/.test(header)
+						? `${header.replace(/;\s*(?:Secure|SameSite=[^;]*)(?=;|$)/gi, "")}; SameSite=None; Secure`
+						: header,
+				),
+			)
+		}
 	}
 }

--- a/src/pages/types.ts
+++ b/src/pages/types.ts
@@ -24,6 +24,7 @@ export type NextApiRequestLike = {
 export type NextApiResponseLike = {
 	redirect(url: string): NextApiResponseLike
 	clearPreviewData(): NextApiResponseLike
+	getHeader(name: string): number | string | string[] | undefined
 	setHeader(name: string, value: string | string[]): NextApiResponseLike
 	// oxlint-disable-next-line no-explicit-any explicit-module-boundary-types
 	json(body: any): void

--- a/src/redirectToPreviewURL.ts
+++ b/src/redirectToPreviewURL.ts
@@ -74,6 +74,18 @@ export async function redirectToPreviewURL(config: RedirectToPreviewURLConfig): 
 	})
 
 	;(await draftMode()).enable()
+	// Next.js uses SameSite=Lax for Draft Mode in development. Keep its
+	// generated value, but allow the editor iframe to send this cookie too.
+	const cookieJar = await cookies()
+	const draftCookie = cookieJar.get("__prerender_bypass")
+	if (draftCookie) {
+		cookieJar.set(draftCookie.name, draftCookie.value, {
+			path: "/",
+			sameSite: "none",
+			secure: true,
+			httpOnly: true,
+		})
+	}
 
 	return redirect(previewURL)
 }

--- a/src/redirectToPreviewURL.ts
+++ b/src/redirectToPreviewURL.ts
@@ -50,10 +50,20 @@ export async function redirectToPreviewURL(config: RedirectToPreviewURLConfig): 
 	// to support unpublished previews. Without setting it here, the page
 	// will try to render without the preview cookie, leading to a
 	// PrismicNotFound error.
+	//
+	// Path=/; SameSite=None; Secure so the cookie is sent when the site is
+	// embedded in a cross-site iframe (e.g. the Platform editor). Chrome
+	// defaults omitted SameSite to Lax and strips the cookie from those
+	// requests. Do not set HttpOnly: the toolbar reads `document.cookie`.
 	const previewToken = request.nextUrl.searchParams.get("token") ?? undefined
 	if (previewToken) {
 		const cookieJar = await cookies()
-		cookieJar.set(prismicCookie.preview, previewToken)
+		cookieJar.set(prismicCookie.preview, previewToken, {
+			path: "/",
+			sameSite: "none",
+			secure: true,
+			httpOnly: false,
+		})
 	}
 
 	const previewURL = await client.resolvePreviewURL({

--- a/tests/getPreviewRef.spec.ts
+++ b/tests/getPreviewRef.spec.ts
@@ -1,0 +1,62 @@
+import type { APIRequestContext } from "@playwright/test"
+
+import { expect, test } from "./infra"
+
+type PreviewRefResponse = {
+	draftModeEnabled: boolean
+	previewRef: string | null
+}
+
+async function getPreviewRef(request: APIRequestContext): Promise<PreviewRefResponse> {
+	const response = await request.get("/api/get-preview-ref-test")
+	expect(response.ok()).toBe(true)
+	return await response.json()
+}
+
+async function setupPreviewRef(
+	request: APIRequestContext,
+	config: { mode: "enable" | "disable"; previewCookie?: string },
+): Promise<void> {
+	const searchParams = new URLSearchParams({ mode: config.mode })
+	if (config.previewCookie !== undefined) {
+		searchParams.set("previewCookie", config.previewCookie)
+	}
+
+	const response = await request.get(`/api/get-preview-ref-test?${searchParams}`)
+	expect(response.ok()).toBe(true)
+}
+
+test.describe("getPreviewRef", () => {
+	for (const previewCookie of [
+		"websitePreviewId=legacy-preview-ref",
+		"m-master-ref:p-overlay-ref",
+		"opaque-preview-ref",
+	]) {
+		test(`returns ${previewCookie} when Draft Mode is enabled`, async ({ request }) => {
+			await setupPreviewRef(request, { mode: "enable", previewCookie })
+
+			await expect(getPreviewRef(request)).resolves.toEqual({
+				draftModeEnabled: true,
+				previewRef: previewCookie,
+			})
+		})
+	}
+
+	test("returns null when Draft Mode is disabled with a preview cookie", async ({ request }) => {
+		await setupPreviewRef(request, { mode: "disable", previewCookie: "opaque-preview-ref" })
+
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: false,
+			previewRef: null,
+		})
+	})
+
+	test("returns null when Draft Mode is enabled without a preview cookie", async ({ request }) => {
+		await setupPreviewRef(request, { mode: "enable" })
+
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: true,
+			previewRef: null,
+		})
+	})
+})

--- a/tests/getPreviewRef.spec.ts
+++ b/tests/getPreviewRef.spec.ts
@@ -27,6 +27,11 @@ async function setupPreviewRef(
 }
 
 test.describe("getPreviewRef", () => {
+	const toolbarPreviewRef = "m-master-ref:p-overlay-ref"
+	const toolbarCookie = JSON.stringify({
+		"example.prismic.io": { preview: toolbarPreviewRef },
+	})
+
 	for (const previewCookie of [
 		"websitePreviewId=legacy-preview-ref",
 		"m-master-ref:p-overlay-ref",
@@ -41,6 +46,31 @@ test.describe("getPreviewRef", () => {
 			})
 		})
 	}
+
+	test("unwraps the toolbar JSON preview cookie when Draft Mode is enabled", async ({
+		request,
+	}) => {
+		await setupPreviewRef(request, { mode: "enable", previewCookie: toolbarCookie })
+
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: true,
+			previewRef: toolbarPreviewRef,
+		})
+	})
+
+	test("returns null when the preview cookie is JSON without a preview field", async ({
+		request,
+	}) => {
+		await setupPreviewRef(request, {
+			mode: "enable",
+			previewCookie: JSON.stringify({ "example.prismic.io": {} }),
+		})
+
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: true,
+			previewRef: null,
+		})
+	})
 
 	test("returns null when Draft Mode is disabled with a preview cookie", async ({ request }) => {
 		await setupPreviewRef(request, { mode: "disable", previewCookie: "opaque-preview-ref" })

--- a/tests/getPreviewRef.spec.ts
+++ b/tests/getPreviewRef.spec.ts
@@ -27,6 +27,43 @@ async function setupPreviewRef(
 }
 
 test.describe("getPreviewRef", () => {
+	test("keeps Draft Mode enabled for cross-site iframe requests in development", async ({
+		request,
+	}) => {
+		const response = await request.get(
+			"/api/get-preview-ref-test?mode=bootstrap&token=opaque-preview-ref",
+			{ maxRedirects: 0 },
+		)
+		expect(response.status()).toBe(307)
+		const setCookies = response
+			.headersArray()
+			.filter((header) => header.name.toLowerCase() === "set-cookie")
+		for (const name of ["io.prismic.preview", "__prerender_bypass"]) {
+			const cookie = setCookies.find((header) => header.value.startsWith(`${name}=`))?.value
+			expect(cookie).toMatch(/; SameSite=None/i)
+			expect(cookie).toMatch(/; Secure/i)
+		}
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: true,
+			previewRef: "opaque-preview-ref",
+		})
+	})
+
+	test("exits the standard preview bootstrap and removes both preview cookies", async ({
+		request,
+	}) => {
+		await request.get("/api/get-preview-ref-test?mode=bootstrap&token=opaque-preview-ref")
+		const response = await request.get("/api/exit-preview")
+		expect(response.ok()).toBe(true)
+		const cookieNames = (await request.storageState()).cookies.map((cookie) => cookie.name)
+		expect(cookieNames).not.toContain("io.prismic.preview")
+		expect(cookieNames).not.toContain("__prerender_bypass")
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: false,
+			previewRef: null,
+		})
+	})
+
 	const toolbarPreviewRef = "m-master-ref:p-overlay-ref"
 	const toolbarCookie = JSON.stringify({
 		_tracker: "https://example.prismic.io",

--- a/tests/getPreviewRef.spec.ts
+++ b/tests/getPreviewRef.spec.ts
@@ -29,6 +29,7 @@ async function setupPreviewRef(
 test.describe("getPreviewRef", () => {
 	const toolbarPreviewRef = "m-master-ref:p-overlay-ref"
 	const toolbarCookie = JSON.stringify({
+		_tracker: "https://example.prismic.io",
 		"example.prismic.io": { preview: toolbarPreviewRef },
 	})
 
@@ -64,6 +65,35 @@ test.describe("getPreviewRef", () => {
 		await setupPreviewRef(request, {
 			mode: "enable",
 			previewCookie: JSON.stringify({ "example.prismic.io": {} }),
+		})
+
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: true,
+			previewRef: null,
+		})
+	})
+
+	test("returns null when the preview cookie is a JSON array", async ({ request }) => {
+		await setupPreviewRef(request, {
+			mode: "enable",
+			previewCookie: JSON.stringify([{ preview: toolbarPreviewRef }]),
+		})
+
+		await expect(getPreviewRef(request)).resolves.toEqual({
+			draftModeEnabled: true,
+			previewRef: null,
+		})
+	})
+
+	test("returns null when the preview cookie has multiple repository previews", async ({
+		request,
+	}) => {
+		await setupPreviewRef(request, {
+			mode: "enable",
+			previewCookie: JSON.stringify({
+				"example.prismic.io": { preview: toolbarPreviewRef },
+				"other.prismic.io": { preview: "other-preview-ref" },
+			}),
 		})
 
 		await expect(getPreviewRef(request)).resolves.toEqual({

--- a/tests/pagesPreviewClient.spec.ts
+++ b/tests/pagesPreviewClient.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "./infra"
+
+test("coalesces updates during a pending Pages preview request to the latest ref", async ({
+	page,
+}) => {
+	const toolbarReady = page.waitForRequest("**/prismic.js*")
+	await page.route("**/prismic.js*", (route) => route.abort())
+	await page.goto("/preview-client-test")
+	await toolbarReady
+	await expect(page.getByTestId("preview-ref")).toHaveText("none")
+	let releaseFirst!: () => void
+	const firstPending = new Promise<void>((resolve) => {
+		releaseFirst = resolve
+	})
+	let requests = 0
+	await page.route("**/api/set-preview-data-test?redirect", async (route) => {
+		requests++
+		if (requests === 1) await firstPending
+		await route.continue()
+	})
+	await page.evaluate(() => {
+		document.documentElement.dataset.previewIdentity = "preserved"
+		document.cookie = "io.prismic.preview=opaque-A; Path=/; SameSite=None; Secure"
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	await expect.poll(() => requests).toBe(1)
+	await page.evaluate(() => {
+		for (const ref of ["opaque-B", "opaque-C"]) {
+			document.cookie = `io.prismic.preview=${ref}; Path=/; SameSite=None; Secure`
+			window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+		}
+	})
+	releaseFirst()
+	await expect(page.getByTestId("preview-ref")).toHaveText("opaque-C")
+	expect(requests).toBe(2)
+	await expect(page.locator("html")).toHaveAttribute("data-preview-identity", "preserved")
+})
+
+test("cancels a pending Pages preview request when the preview ends", async ({ page }) => {
+	const toolbarReady = page.waitForRequest("**/prismic.js*")
+	await page.route("**/prismic.js*", (route) => route.abort())
+	await page.goto("/preview-client-test")
+	await toolbarReady
+	await expect(page.getByTestId("preview-ref")).toHaveText("none")
+	let release!: () => void
+	const pending = new Promise<void>((resolve) => {
+		release = resolve
+	})
+	await page.route("**/api/set-preview-data-test?redirect", async (route) => {
+		await pending
+		await route.continue()
+	})
+	const started = page.waitForRequest("**/api/set-preview-data-test?redirect")
+	await page.evaluate(() => {
+		document.cookie = "io.prismic.preview=opaque-ref; Path=/; SameSite=None; Secure"
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	const previewRequest = await started
+	const aborted = page.waitForEvent("requestfailed", (request) => request === previewRequest)
+	const exited = page.waitForResponse("**/api/exit-preview")
+	await page.evaluate(() => {
+		window.dispatchEvent(new Event("prismicPreviewEnd", { cancelable: true }))
+	})
+	await exited
+	release()
+	await aborted
+	await expect(page.getByTestId("preview-ref")).toHaveText("none")
+	expect((await page.context().cookies()).map((cookie) => cookie.name)).not.toContain(
+		"__prerender_bypass",
+	)
+})

--- a/tests/previewClient.spec.ts
+++ b/tests/previewClient.spec.ts
@@ -1,0 +1,139 @@
+import type { Page } from "@playwright/test"
+
+import { test, expect } from "./infra"
+
+async function openPreviewPage(page: Page, url: string): Promise<void> {
+	// The real toolbar is lazy-loaded after the SDK's listeners mount.
+	const toolbarReady = page.waitForRequest("**/prismic.js*")
+	await page.route("**/prismic.js*", (route) => route.abort())
+	await page.goto(url)
+	await toolbarReady
+}
+
+test("recovers an unpublished page when preview starts from a not-found screen", async ({
+	page,
+}) => {
+	await openPreviewPage(page, "/preview-recovery-test")
+	await expect(page.getByRole("heading", { name: "Document not found" })).toBeVisible()
+	const activated = page.waitForRequest("**/prismic.js*")
+	await page.evaluate(() => {
+		document.cookie = "io.prismic.preview=opaque-unpublished-ref; Path=/; SameSite=None; Secure"
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	await activated
+	await expect(page.getByTestId("preview-ref")).toHaveText("opaque-unpublished-ref")
+	await page.evaluate(() => {
+		document.documentElement.dataset.previewIdentity = "preserved"
+		document.cookie = "io.prismic.preview=opaque-recovered-update; Path=/; SameSite=None; Secure"
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	await expect(page.getByTestId("preview-ref")).toHaveText("opaque-recovered-update")
+	await expect(page.locator("html")).toHaveAttribute("data-preview-identity", "preserved")
+})
+
+test("keeps Draft Mode and live refs inside a cross-site HTTP localhost iframe", async ({
+	page,
+}) => {
+	await page.context().grantPermissions(["local-network-access"], {
+		origin: "http://127.0.0.1:4321",
+	})
+	await page.route("http://127.0.0.1:4321/iframe-test", (route) =>
+		route.fulfill({
+			contentType: "text/html",
+			body: '<iframe src="http://localhost:4321/api/get-preview-ref-test?mode=bootstrap&client&token=opaque-initial-ref"></iframe>',
+		}),
+	)
+	await openPreviewPage(page, "http://127.0.0.1:4321/iframe-test")
+	const frame = page.frameLocator("iframe")
+	await expect(frame.getByTestId("draft-mode")).toHaveText("true")
+	await expect(frame.getByTestId("preview-ref")).toHaveText("opaque-initial-ref")
+	await frame.locator("html").evaluate((element) => {
+		element.dataset.previewIdentity = "preserved"
+		document.cookie = "io.prismic.preview=opaque-iframe-update; Path=/; SameSite=None; Secure"
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	await expect(frame.getByTestId("preview-ref")).toHaveText("opaque-iframe-update")
+	await expect(frame.locator("html")).toHaveAttribute("data-preview-identity", "preserved")
+})
+
+test("bootstraps opaque pushed refs once, then refreshes in place", async ({ page }) => {
+	await openPreviewPage(page, "/preview-client-test")
+	await expect(page.getByTestId("draft-mode")).toHaveText("false")
+	await expect(page.getByTestId("preview-ref")).toHaveText("none")
+
+	await page.evaluate(() => {
+		document.cookie = "io.prismic.preview=opaque-first-ref; Path=/; SameSite=None; Secure"
+	})
+	expect(await page.context().cookies()).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ name: "io.prismic.preview", value: "opaque-first-ref" }),
+		]),
+	)
+
+	let bootstrapRequests = 0
+	let finishBootstrap!: () => void
+	const bootstrapPending = new Promise<void>((resolve) => {
+		finishBootstrap = resolve
+	})
+	await page.route("**/api/get-preview-ref-test?mode=bootstrap", async (route) => {
+		bootstrapRequests++
+		await bootstrapPending
+		await route.continue()
+	})
+
+	await page.evaluate(() => {
+		for (let i = 0; i < 3; i++) {
+			window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+		}
+	})
+	await expect.poll(() => bootstrapRequests).toBe(1)
+	const activated = page.waitForRequest("**/prismic.js*")
+	finishBootstrap()
+	await activated
+	await expect(page.getByTestId("draft-mode")).toHaveText("true")
+	await expect(page.getByTestId("preview-ref")).toHaveText("opaque-first-ref")
+
+	await page.evaluate(() => {
+		document.documentElement.dataset.previewIdentity = "preserved"
+		document.cookie = "io.prismic.preview=opaque-updated-ref; Path=/; SameSite=None; Secure"
+	})
+	await page.evaluate(() => {
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	await expect(page.getByTestId("preview-ref")).toHaveText("opaque-updated-ref")
+	expect(bootstrapRequests).toBe(1)
+	await expect(page.locator("html")).toHaveAttribute("data-preview-identity", "preserved")
+})
+
+test("cancels a pending bootstrap when the preview ends", async ({ page }) => {
+	await openPreviewPage(page, "/preview-client-test")
+	await expect(page.getByTestId("draft-mode")).toHaveText("false")
+
+	let finishBootstrap!: () => void
+	const bootstrapPending = new Promise<void>((resolve) => {
+		finishBootstrap = resolve
+	})
+	await page.route("**/api/get-preview-ref-test?mode=bootstrap", async (route) => {
+		await bootstrapPending
+		await route.continue()
+	})
+	const started = page.waitForRequest("**/api/get-preview-ref-test?mode=bootstrap")
+	await page.evaluate(() => {
+		document.cookie = "io.prismic.preview=opaque-ref; Path=/; SameSite=None; Secure"
+		window.dispatchEvent(new Event("prismicPreviewUpdate", { cancelable: true }))
+	})
+	const bootstrapRequest = await started
+	const aborted = page.waitForEvent("requestfailed", (request) => request === bootstrapRequest)
+	const exited = page.waitForResponse("**/api/exit-preview")
+	await page.evaluate(() => {
+		window.dispatchEvent(new Event("prismicPreviewEnd", { cancelable: true }))
+	})
+	await exited
+	finishBootstrap()
+	await aborted
+	await expect(page.getByTestId("draft-mode")).toHaveText("false")
+	await expect(page.getByTestId("preview-ref")).toHaveText("none")
+	expect((await page.context().cookies()).map((cookie) => cookie.name)).not.toContain(
+		"__prerender_bypass",
+	)
+})

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -63,14 +63,12 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 	}
 
 	// Toolbar leftover: JSON value with `"<repo>.prismic.io"`, SameSite=Lax,
-	// not Secure. Expiring only None; Secure leaves this cookie; then
-	// `<PrismicPreview>` `start()` replays `/api/preview`.
+	// not Secure. Host-only (no Domain), matching `document.cookie`.
 	await page.context().addCookies([
 		{
 			name: cookie.preview,
 			value: JSON.stringify({ [`${repo.domain}.prismic.io`]: { preview: "toolbar" } }),
-			domain: "localhost",
-			path: "/",
+			url: new URL("/", page.url()).href,
 			sameSite: "Lax",
 			secure: false,
 			httpOnly: false,
@@ -79,6 +77,11 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 
 	await page.goto("/api/exit-preview")
 	expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toBeUndefined()
+
+	// The toolbar can write `io.prismic.preview` again on the next page load.
+	// Abort it so a `/api/preview` hit is from `<PrismicPreview>` `start()`.
+	await page.route("**/prismic.js*", (route) => route.abort())
+	await page.route("**/prismic-toolbar/**", (route) => route.abort())
 
 	const previewRequests: string[] = []
 	page.on("request", (request) => {
@@ -89,7 +92,6 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 
 	await appPage.goToDocument(pageDoc)
 	await expect(appPage.payload).toBeVisible()
-	await expect(appPage.toolbarScript).toHaveCount(1)
 	// `<PrismicPreview>` `start()` runs in `useEffect` after mount.
 	await page.waitForTimeout(1000)
 	expect(previewRequests).toEqual([])

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -55,8 +55,7 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 
 	const updatedDocument = await repo.createDocumentDraft(pageDoc, content({ payload: "foo" }))
 	await appPage.preview(updatedDocument)
-	const previewCookie = (await page.context().cookies()).find((c) => c.name === cookie.preview)
-	expect(previewCookie).toMatchObject({
+	expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toMatchObject({
 		name: cookie.preview,
 		path: "/",
 		sameSite: "None",
@@ -65,9 +64,10 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 	})
 
 	// Exit via the endpoint directly so the assertion does not depend on the
-	// Prismic toolbar loading.
+	// Prismic toolbar loading. The expired overwrite must clear this
+	// SameSite=None; Secure cookie, not leave it behind.
 	await page.goto("/api/exit-preview")
-	expect((await page.context().cookies()).map((c) => c.name)).not.toContain(cookie.preview)
+	expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toBeUndefined()
 })
 
 // We can't get a real shareable link because we aren't authenticated with a

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -49,19 +49,32 @@ test("restores published pageDoc on exit", async ({ appPage, repo, pageDoc }) =>
 })
 
 test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc }, testInfo) => {
-	// `exitPreview` clears the Prismic preview cookie. The Pages Router stores
-	// preview state in Next.js preview data instead, so this is App Router only.
-	test.skip(testInfo.project.name !== "app-router", "App Router only")
-
 	const updatedDocument = await repo.createDocumentDraft(pageDoc, content({ payload: "foo" }))
 	await appPage.preview(updatedDocument)
-	expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toMatchObject({
-		name: cookie.preview,
-		path: "/",
-		sameSite: "None",
-		secure: true,
-		httpOnly: false,
-	})
+
+	if (testInfo.project.name === "app-router") {
+		expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toMatchObject({
+			name: cookie.preview,
+			path: "/",
+			sameSite: "None",
+			secure: true,
+			httpOnly: false,
+		})
+	} else {
+		// Pages Router does not write `io.prismic.preview`. Plant the iframe-safe
+		// shape so `exitPreview` must expire it (toolbar leftover → start()).
+		await page.context().addCookies([
+			{
+				name: cookie.preview,
+				value: "planted",
+				domain: "localhost",
+				path: "/",
+				sameSite: "None",
+				secure: true,
+				httpOnly: false,
+			},
+		])
+	}
 
 	// Exit via the endpoint directly so the assertion does not depend on the
 	// Prismic toolbar loading. The expired overwrite must clear this

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -55,7 +55,14 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 
 	const updatedDocument = await repo.createDocumentDraft(pageDoc, content({ payload: "foo" }))
 	await appPage.preview(updatedDocument)
-	expect((await page.context().cookies()).map((c) => c.name)).toContain(cookie.preview)
+	const previewCookie = (await page.context().cookies()).find((c) => c.name === cookie.preview)
+	expect(previewCookie).toMatchObject({
+		name: cookie.preview,
+		path: "/",
+		sameSite: "None",
+		secure: true,
+		httpOnly: false,
+	})
 
 	// Exit via the endpoint directly so the assertion does not depend on the
 	// Prismic toolbar loading.

--- a/tests/previews.spec.ts
+++ b/tests/previews.spec.ts
@@ -60,26 +60,39 @@ test("clears the preview cookie on exit", async ({ appPage, page, repo, pageDoc 
 			secure: true,
 			httpOnly: false,
 		})
-	} else {
-		// Pages Router does not write `io.prismic.preview`. Plant the iframe-safe
-		// shape so `exitPreview` must expire it (toolbar leftover → start()).
-		await page.context().addCookies([
-			{
-				name: cookie.preview,
-				value: "planted",
-				domain: "localhost",
-				path: "/",
-				sameSite: "None",
-				secure: true,
-				httpOnly: false,
-			},
-		])
 	}
 
-	// Exit via the endpoint directly so the assertion does not depend on the
-	// Prismic toolbar loading. The expired overwrite must clear this
-	// SameSite=None; Secure cookie, not leave it behind.
+	// Toolbar leftover: JSON value with `"<repo>.prismic.io"`, SameSite=Lax,
+	// not Secure. Expiring only None; Secure leaves this cookie; then
+	// `<PrismicPreview>` `start()` replays `/api/preview`.
+	await page.context().addCookies([
+		{
+			name: cookie.preview,
+			value: JSON.stringify({ [`${repo.domain}.prismic.io`]: { preview: "toolbar" } }),
+			domain: "localhost",
+			path: "/",
+			sameSite: "Lax",
+			secure: false,
+			httpOnly: false,
+		},
+	])
+
 	await page.goto("/api/exit-preview")
+	expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toBeUndefined()
+
+	const previewRequests: string[] = []
+	page.on("request", (request) => {
+		if (new URL(request.url()).pathname === "/api/preview") {
+			previewRequests.push(request.url())
+		}
+	})
+
+	await appPage.goToDocument(pageDoc)
+	await expect(appPage.payload).toBeVisible()
+	await expect(appPage.toolbarScript).toHaveCount(1)
+	// `<PrismicPreview>` `start()` runs in `useEffect` after mount.
+	await page.waitForTimeout(1000)
+	expect(previewRequests).toEqual([])
 	expect((await page.context().cookies()).find((c) => c.name === cookie.preview)).toBeUndefined()
 })
 

--- a/tests/setPreviewData.spec.ts
+++ b/tests/setPreviewData.spec.ts
@@ -36,6 +36,37 @@ async function readPreviewRef(request: APIRequestContext): Promise<unknown> {
 }
 
 test.describe("setPreviewData", () => {
+	test("keeps Preview Mode cookies available to cross-site iframe requests in development", async ({
+		request,
+	}) => {
+		const response = await request.get("/api/set-preview-data-test?token=opaque-preview-ref")
+		expect(response.ok()).toBe(true)
+		const setCookies = response
+			.headersArray()
+			.filter((header) => header.name.toLowerCase() === "set-cookie")
+		expect(setCookies.map((header) => header.value)).toContain(
+			"unrelated=value; Path=/; HttpOnly; SameSite=Lax",
+		)
+		for (const name of ["__prerender_bypass", "__next_preview_data"]) {
+			const cookie = setCookies.find((header) => header.value.startsWith(`${name}=`))?.value
+			expect(cookie).toMatch(/; SameSite=None/i)
+			expect(cookie).toMatch(/; Secure/i)
+			expect(cookie).toMatch(/; HttpOnly/i)
+		}
+		await expect(readPreviewRef(request)).resolves.toBe("opaque-preview-ref")
+	})
+
+	test("exits Preview Mode and removes both Next preview cookies", async ({ request }) => {
+		await setupPreviewData(request, { token: "opaque-preview-ref" })
+		const response = await request.get("/api/exit-preview")
+		expect(response.ok()).toBe(true)
+		const cookieNames = (await request.storageState()).cookies.map((cookie) => cookie.name)
+		expect(cookieNames).not.toContain("__prerender_bypass")
+		expect(cookieNames).not.toContain("__next_preview_data")
+		expect(cookieNames).toContain("unrelated")
+		await expect(readPreviewRef(request)).resolves.toBeNull()
+	})
+
 	test("stores a token query value as-is", async ({ request }) => {
 		await setupPreviewData(request, { token: "opaque-preview-ref" })
 

--- a/tests/setPreviewData.spec.ts
+++ b/tests/setPreviewData.spec.ts
@@ -10,11 +10,14 @@ const toolbarCookie = JSON.stringify({
 
 async function setupPreviewData(
 	request: APIRequestContext,
-	config: { token?: string; previewCookie?: string },
+	config: { token?: string | string[]; previewCookie?: string },
 ): Promise<void> {
 	const searchParams = new URLSearchParams()
 	if (config.token !== undefined) {
-		searchParams.set("token", config.token)
+		const tokens = Array.isArray(config.token) ? config.token : [config.token]
+		for (const token of tokens) {
+			searchParams.append("token", token)
+		}
 	}
 	if (config.previewCookie !== undefined) {
 		searchParams.set("previewCookie", config.previewCookie)
@@ -34,9 +37,9 @@ async function readPreviewRef(request: APIRequestContext): Promise<unknown> {
 
 test.describe("setPreviewData", () => {
 	test("stores a token query value as-is", async ({ request }) => {
-		await setupPreviewData(request, { token: "opaque-preview-token" })
+		await setupPreviewData(request, { token: "opaque-preview-ref" })
 
-		await expect(readPreviewRef(request)).resolves.toBe("opaque-preview-token")
+		await expect(readPreviewRef(request)).resolves.toBe("opaque-preview-ref")
 	})
 
 	test("does not unwrap a token query that looks like a toolbar jar", async ({ request }) => {
@@ -59,11 +62,22 @@ test.describe("setPreviewData", () => {
 
 	test("prefers the token query over a preview cookie", async ({ request }) => {
 		await setupPreviewData(request, {
-			token: "query-token",
+			token: "query-preview-ref",
 			previewCookie: toolbarCookie,
 		})
 
-		await expect(readPreviewRef(request)).resolves.toBe("query-token")
+		await expect(readPreviewRef(request)).resolves.toBe("query-preview-ref")
+	})
+
+	test("stores repeated token query values as an ordered array", async ({ request }) => {
+		const queryValues = ["query-preview-ref-one", "query-preview-ref-two"]
+
+		await setupPreviewData(request, {
+			token: queryValues,
+			previewCookie: toolbarCookie,
+		})
+
+		await expect(readPreviewRef(request)).resolves.toEqual(queryValues)
 	})
 
 	test("stores nothing when the preview cookie is JSON without a preview field", async ({

--- a/tests/setPreviewData.spec.ts
+++ b/tests/setPreviewData.spec.ts
@@ -1,0 +1,76 @@
+import type { Page } from "@playwright/test"
+
+import { expect, test } from "./infra"
+
+const toolbarPreviewRef = "m-master-ref:p-overlay-ref"
+const toolbarCookie = JSON.stringify({
+	_tracker: "https://example.prismic.io",
+	"example.prismic.io": { preview: toolbarPreviewRef },
+})
+
+async function setupPreviewData(
+	page: Page,
+	config: { token?: string; previewCookie?: string },
+): Promise<void> {
+	const searchParams = new URLSearchParams()
+	if (config.token !== undefined) {
+		searchParams.set("token", config.token)
+	}
+	if (config.previewCookie !== undefined) {
+		searchParams.set("previewCookie", config.previewCookie)
+	}
+
+	const response = await page.request.get(`/api/set-preview-data-test?${searchParams}`)
+	expect(response.ok()).toBe(true)
+}
+
+async function readPreviewRef(page: Page): Promise<unknown> {
+	await page.goto("/set-preview-data-test")
+	const text = await page.getByTestId("preview-ref").textContent()
+	return JSON.parse(text ?? "null")
+}
+
+test.describe("setPreviewData", () => {
+	test("stores a token query value as-is", async ({ page }) => {
+		await setupPreviewData(page, { token: "opaque-preview-token" })
+
+		await expect(readPreviewRef(page)).resolves.toBe("opaque-preview-token")
+	})
+
+	test("does not unwrap a token query that looks like a toolbar jar", async ({ page }) => {
+		await setupPreviewData(page, { token: toolbarCookie })
+
+		await expect(readPreviewRef(page)).resolves.toBe(toolbarCookie)
+	})
+
+	test("unwraps a toolbar JSON preview cookie", async ({ page }) => {
+		await setupPreviewData(page, { previewCookie: toolbarCookie })
+
+		await expect(readPreviewRef(page)).resolves.toBe(toolbarPreviewRef)
+	})
+
+	test("stores a raw cookie token", async ({ page }) => {
+		await setupPreviewData(page, { previewCookie: "opaque-preview-ref" })
+
+		await expect(readPreviewRef(page)).resolves.toBe("opaque-preview-ref")
+	})
+
+	test("prefers the token query over a preview cookie", async ({ page }) => {
+		await setupPreviewData(page, {
+			token: "query-token",
+			previewCookie: toolbarCookie,
+		})
+
+		await expect(readPreviewRef(page)).resolves.toBe("query-token")
+	})
+
+	test("stores nothing when the preview cookie is JSON without a preview field", async ({
+		page,
+	}) => {
+		await setupPreviewData(page, {
+			previewCookie: JSON.stringify({ "example.prismic.io": {} }),
+		})
+
+		await expect(readPreviewRef(page)).resolves.toBeNull()
+	})
+})

--- a/tests/setPreviewData.spec.ts
+++ b/tests/setPreviewData.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { APIRequestContext } from "@playwright/test"
 
 import { expect, test } from "./infra"
 
@@ -9,7 +9,7 @@ const toolbarCookie = JSON.stringify({
 })
 
 async function setupPreviewData(
-	page: Page,
+	request: APIRequestContext,
 	config: { token?: string; previewCookie?: string },
 ): Promise<void> {
 	const searchParams = new URLSearchParams()
@@ -20,57 +20,59 @@ async function setupPreviewData(
 		searchParams.set("previewCookie", config.previewCookie)
 	}
 
-	const response = await page.request.get(`/api/set-preview-data-test?${searchParams}`)
+	const response = await request.get(`/api/set-preview-data-test?${searchParams}`)
 	expect(response.ok()).toBe(true)
 }
 
-async function readPreviewRef(page: Page): Promise<unknown> {
-	await page.goto("/set-preview-data-test")
-	const text = await page.getByTestId("preview-ref").textContent()
-	return JSON.parse(text ?? "null")
+async function readPreviewRef(request: APIRequestContext): Promise<unknown> {
+	const response = await request.get("/set-preview-data-test", {
+		headers: { Accept: "application/json" },
+	})
+	expect(response.ok()).toBe(true)
+	return (await response.json()).previewRef
 }
 
 test.describe("setPreviewData", () => {
-	test("stores a token query value as-is", async ({ page }) => {
-		await setupPreviewData(page, { token: "opaque-preview-token" })
+	test("stores a token query value as-is", async ({ request }) => {
+		await setupPreviewData(request, { token: "opaque-preview-token" })
 
-		await expect(readPreviewRef(page)).resolves.toBe("opaque-preview-token")
+		await expect(readPreviewRef(request)).resolves.toBe("opaque-preview-token")
 	})
 
-	test("does not unwrap a token query that looks like a toolbar jar", async ({ page }) => {
-		await setupPreviewData(page, { token: toolbarCookie })
+	test("does not unwrap a token query that looks like a toolbar jar", async ({ request }) => {
+		await setupPreviewData(request, { token: toolbarCookie })
 
-		await expect(readPreviewRef(page)).resolves.toBe(toolbarCookie)
+		await expect(readPreviewRef(request)).resolves.toBe(toolbarCookie)
 	})
 
-	test("unwraps a toolbar JSON preview cookie", async ({ page }) => {
-		await setupPreviewData(page, { previewCookie: toolbarCookie })
+	test("unwraps a toolbar JSON preview cookie", async ({ request }) => {
+		await setupPreviewData(request, { previewCookie: toolbarCookie })
 
-		await expect(readPreviewRef(page)).resolves.toBe(toolbarPreviewRef)
+		await expect(readPreviewRef(request)).resolves.toBe(toolbarPreviewRef)
 	})
 
-	test("stores a raw cookie token", async ({ page }) => {
-		await setupPreviewData(page, { previewCookie: "opaque-preview-ref" })
+	test("stores a raw cookie token", async ({ request }) => {
+		await setupPreviewData(request, { previewCookie: "opaque-preview-ref" })
 
-		await expect(readPreviewRef(page)).resolves.toBe("opaque-preview-ref")
+		await expect(readPreviewRef(request)).resolves.toBe("opaque-preview-ref")
 	})
 
-	test("prefers the token query over a preview cookie", async ({ page }) => {
-		await setupPreviewData(page, {
+	test("prefers the token query over a preview cookie", async ({ request }) => {
+		await setupPreviewData(request, {
 			token: "query-token",
 			previewCookie: toolbarCookie,
 		})
 
-		await expect(readPreviewRef(page)).resolves.toBe("query-token")
+		await expect(readPreviewRef(request)).resolves.toBe("query-token")
 	})
 
 	test("stores nothing when the preview cookie is JSON without a preview field", async ({
-		page,
+		request,
 	}) => {
-		await setupPreviewData(page, {
+		await setupPreviewData(request, {
 			previewCookie: JSON.stringify({ "example.prismic.io": {} }),
 		})
 
-		await expect(readPreviewRef(page)).resolves.toBeNull()
+		await expect(readPreviewRef(request)).resolves.toBeNull()
 	})
 })


### PR DESCRIPTION
<!-- Title: fix: keep previews live in editor and standalone tabs -->

**TL;DR** — Make the standard Next.js preview helpers support cross-site editor previews on HTTP localhost and keep active previews updating in place.

Next.js development cookies can drop Draft/Preview Mode inside the editor iframe, while toolbar cookies can contain either a raw ref or a repository jar. This PR handles those formats through the standard App and Pages APIs, completes preview activation when an update arrives, and clears preview state on exit.

## Product & functional impact

**Standard integration** — App and Pages preview routes handle local preview cookies without application-level cookie workarounds.

**Live updates** — Active App previews refresh in place; Pages previews serialize pending updates and render the latest ref.

**Preview lifecycle** — Ending a preview cancels pending activation and expires both legacy Lax and cross-site cookie variants.

## Code-level impacts

**Opaque refs** — Preserve raw refs and query-token precedence, including repeated Pages query tokens as ordered arrays; unwrap only an unambiguous single-preview cookie jar.

**Next-owned state** — Retain Next.js-generated Draft/Preview Mode values and signed data while setting `SameSite=None; Secure`, including in development; preserve unrelated response cookies.

**Activation races** — Coalesce concurrent starts and abort pending requests on exit or component cleanup.

## Verification

**Automated coverage** — 26 focused request/browser tests pass under both `next dev` and `next start`; 6 production-build/tree-shaking checks pass across App Router, Pages Router, and Next.js 15.

**Local checks** — Package build, lint, types, and diff whitespace checks pass. Final authenticated Platform editor `dd1073824` + toolbar #131 `6c6ab38` + published alpha `2.3.1-pr.147.286b2d0` passed on HTTP localhost under `next dev`, using the real SDK helpers and component: Form/Properties, two editor tabs, already-open standalone, cold 404 activation, exit/reopen, and UID navigation. Active title updates retained all three page documents.

**CI** — [Node 20/22/24 checks pass](https://github.com/prismicio/prismic-next/actions/runs/33929013092). The existing legacy `updates previews` test on Node 20 timed out on its first five-second assertion and passed on retry; the cause is not established. Node 22/24 passed on the first attempt.

## Trade-offs

**Initial activation** — App Router performs one full reload when entering Draft Mode, allowing an unpublished page to recover from Next.js's not-found boundary; subsequent preview updates remain soft.

**Browser policy** — HTTP localhost is covered in Chromium; browser cookie and local-network restrictions still apply, and arbitrary HTTP hostnames are not made secure contexts by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes preview session cookies, Draft/Preview Mode activation, and exit semantics across App and Pages Router—security-sensitive paths that affect all consumers of the standard preview helpers.
> 
> **Overview**
> Fixes Prismic preview sessions so they stay live in the Platform editor iframe and in standalone tabs on HTTP localhost, without app-level cookie workarounds.
> 
> **Cookie & ref handling** — `getPreviewRef` and Pages `setPreviewData` now unwrap toolbar JSON `io.prismic.preview` jars via `previewRefFromCookie` while keeping raw refs and query `token` precedence (including repeated Pages tokens). `redirectToPreviewURL` and `setPreviewData` rewrite Next preview/draft cookies to **`SameSite=None; Secure`** so Draft/Preview Mode survives cross-site iframes in development.
> 
> **Lifecycle** — App and Pages `exitPreview` stop relying on name-keyed cookie APIs alone and **expire every preview/draft cookie variant** (Lax toolbar + iframe writes, `__prerender_bypass`, `__next_preview_data`) so leftover cookies cannot re-trigger `/api/preview`.
> 
> **`<PrismicPreview>` client** — App Router uses a **full reload** only on first Draft Mode activation (not-found recovery); later updates soft-refresh. Both routers **coalesce concurrent starts**, abort in-flight bootstrap on exit/unmount, and Pages serializes rapid toolbar updates to the latest ref.
> 
> **Verification** — New e2e harness routes, dedicated Playwright projects, and expanded cookie/iframe/race tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565ab094da7d926e9b8330b81b2750ee4b2a3d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->